### PR TITLE
Set default encoding utf8

### DIFF
--- a/jollyday-jaxb/pom.xml
+++ b/jollyday-jaxb/pom.xml
@@ -118,6 +118,7 @@
               </systemProperties>
               <jvmArguments>
                 <jvmArgument>-Xms32m</jvmArgument>
+				<jvmArgument>-Dfile.encoding=UTF-8</jvmArgument>
               </jvmArguments>
               <arguments>
                 <!-- These are the arguments you would normally

--- a/jollyday-jaxb/pom.xml
+++ b/jollyday-jaxb/pom.xml
@@ -118,7 +118,7 @@
               </systemProperties>
               <jvmArguments>
                 <jvmArgument>-Xms32m</jvmArgument>
-				<jvmArgument>-Dfile.encoding=UTF-8</jvmArgument>
+                <jvmArgument>-Dfile.encoding=UTF-8</jvmArgument>
               </jvmArguments>
               <arguments>
                 <!-- These are the arguments you would normally


### PR DESCRIPTION
# Change
On different platforms, different default charsets are used.
This change sets the default encoding in the jaxb generation to utf-8.
Fixes #108 

