### PR TITLE
Added missing Children's Day to Romanian xml config

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_ro.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_ro.xml
@@ -7,6 +7,7 @@
     <tns:Fixed month="JANUARY" day="2" descriptionPropertiesKey="NEW_YEAR"/>
     <tns:Fixed month="JANUARY" day="24" validFrom="2017" descriptionPropertiesKey="UNIFICATION"/>
     <tns:Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
+    <tns:Fixed month="JUNE" day="1" validFrom="2017" descriptionPropertiesKey="CHILDRENS_DAY"/>
     <tns:Fixed month="AUGUST" day="15" descriptionPropertiesKey="NAVY_DAY"/>
     <tns:Fixed month="NOVEMBER" day="30" descriptionPropertiesKey="ST_ANDREW"/>
     <tns:Fixed month="DECEMBER" day="1" descriptionPropertiesKey="NATIONAL_DAY"/>


### PR DESCRIPTION
- the Children's Day is treated as official holiday since 2017 in Romania