### PR TITLE
added descriptionPropertiesKey for EASTER and EASTER_MONDAY in Holidays_md.xml (Moldova holidays configuration file)

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_md.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_md.xml
@@ -10,8 +10,8 @@
     <tns:Fixed month="MAY" day="9" descriptionPropertiesKey="VICTORY"/>
     <tns:Fixed month="AUGUST" day="27" descriptionPropertiesKey="INDEPENDENCE_DAY"/>
     <tns:Fixed month="AUGUST" day="31" descriptionPropertiesKey="LANGUAGE_DAY"/>
-    <tns:ChristianHoliday type="EASTER" chronology="JULIAN"/>
-    <tns:ChristianHoliday type="EASTER_MONDAY" chronology="JULIAN"/>
+    <tns:ChristianHoliday type="EASTER" chronology="JULIAN" descriptionPropertiesKey="christian.EASTER"/>
+    <tns:ChristianHoliday type="EASTER_MONDAY" chronology="JULIAN" descriptionPropertiesKey="christian.EASTER_MONDAY"/>
   </tns:Holidays>
   <tns:SubConfigurations hierarchy="bti" description="Balti">
     <tns:Holidays>


### PR DESCRIPTION
`EASTER` and `EASTER_MONDAY` entries in `Holidays_md.xml` configuration file were missing `descriptionPropertiesKey` property. Based on config files for Poland and Romania I've updated Moldova configuration file.

Without `descriptionPropertiesKey` holiday manager returns empty descriptions for Easter and Easter Monday for Moldova.