### PR TITLE
Fix good Friday description for the netherlands

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_nl.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_nl.xml
@@ -18,7 +18,7 @@
     <tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <tns:Fixed month="DECEMBER" day="26" descriptionPropertiesKey="CHRISTMAS"/>
     <tns:ChristianHoliday type="EASTER" descriptionPropertiesKey="christian.EASTER"/>
-    <tns:ChristianHoliday type="GOOD_FRIDAY" localizedType="UNOFFICIAL_HOLIDAY"/>
+    <tns:ChristianHoliday type="GOOD_FRIDAY" localizedType="UNOFFICIAL_HOLIDAY" descriptionPropertiesKey="christian.GOOD_FRIDAY"/>
     <tns:ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"/>
     <tns:ChristianHoliday type="ASCENSION_DAY" descriptionPropertiesKey="christian.ASCENSION_DAY"/>
     <tns:ChristianHoliday type="WHIT_SUNDAY" descriptionPropertiesKey="christian.WHIT_SUNDAY"/>


### PR DESCRIPTION
Currently Good Friday in the Netherlands gets described with 'undefined'. The change should adjust the behaviour to also have the description 'Good Friday'.

closes #245

