### PR TITLE
slovenia: christmas was no public holiday between 1953 and 1990

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_si.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_si.xml
@@ -14,7 +14,8 @@
     <tns:Fixed month="AUGUST" day="15" validFrom="1992" descriptionPropertiesKey="ASSUMPTION_DAY"/>
     <tns:Fixed month="OCTOBER" day="31" validFrom="1992" descriptionPropertiesKey="REFORMATION_DAY"/>
     <tns:Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
-    <tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+    <tns:Fixed month="DECEMBER" validTo="1952" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+    <tns:Fixed month="DECEMBER" validFrom="1991" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <tns:Fixed month="DECEMBER" day="26" descriptionPropertiesKey="INDEPENDENCE_DAY"/>
     <tns:ChristianHoliday type="EASTER" descriptionPropertiesKey="christian.EASTER"/>
     <tns:ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"/>

--- a/jollyday-tests/src/test/java/de/focus_shift/tests/HolidaySITest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/tests/HolidaySITest.java
@@ -165,12 +165,30 @@ class HolidaySITest extends AbstractCountryTestBase {
   }
 
   @Property
-  void ensuresThatChristmasIsConfigured(@ForAll @YearRange Year year) {
+  void ensuresThatChristmasIsConfiguredUntil1952(@ForAll @YearRange(max = 1952) Year year) {
     final HolidayManager holidayManager = HolidayManager.getInstance(create(SLOWENIA));
     final Set<Holiday> holidays = holidayManager.getHolidays(year.getValue());
     assertThat(holidays)
       .isNotEmpty()
       .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+  }
+
+  @Property
+  void ensuresThatChristmasIsConfiguredSince1991(@ForAll @YearRange(min = 1991) Year year) {
+    final HolidayManager holidayManager = HolidayManager.getInstance(create(SLOWENIA));
+    final Set<Holiday> holidays = holidayManager.getHolidays(year.getValue());
+    assertThat(holidays)
+      .isNotEmpty()
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+  }
+
+  @Property
+  void ensuresThatChristmasIsNotConfiguredSince1953Until1990(@ForAll @YearRange(min = 1953, max = 1990) Year year) {
+    final HolidayManager holidayManager = HolidayManager.getInstance(create(SLOWENIA));
+    final Set<Holiday> holidays = holidayManager.getHolidays(year.getValue());
+    assertThat(holidays)
+      .isNotEmpty()
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
   }
 
   @Property


### PR DESCRIPTION
refs #247 

see https://en.wikipedia.org/wiki/Public_holidays_in_Slovenia