### PR TITLE
Add OSGi bundle manifest headers

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,2 @@
+Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
+Export-Package: de.focus_shift*

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>bnd-maven-plugin</artifactId>
+          <version>6.4.0</version>
+        </plugin>
+
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.1.2</version>
@@ -159,6 +165,28 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
This adds back the bundle headers to the manifest so the bundles can be more easily used with OSGi. 


I gave it a brief test with Apache Karaf and the bundles started when all the dependencies are there:

```
karaf@root()> install -s mvn:org.threeten/threeten-extra/1.7.2
> install -s mvn:jakarta.activation/jakarta.activation-api/2.1.2
> install -s mvn:jakarta.xml.bind/jakarta.xml.bind-api/4.0.0
> install -s mvn:de.focus-shift/jollyday-core/0.18.0-SNAPSHOT
> install -s mvn:de.focus-shift/jollyday-jaxb/0.18.0-SNAPSHOT
Bundle ID: 52
Bundle ID: 53
Bundle ID: 54
Bundle ID: 55
Bundle ID: 56

karaf@root()> bundle:list
START LEVEL 100 , List Threshold: 50
ID │ State  │ Lvl │ Version             │ Name
───┼────────┼─────┼─────────────────────┼─────────────────────────────────────────
32 │ Active │  80 │ 4.4.4.SNAPSHOT      │ Apache Karaf :: OSGi Services :: Event
52 │ Active │  80 │ 1.7.2               │ ThreeTen-Extra
53 │ Active │  80 │ 2.1.2               │ Jakarta Activation API
54 │ Active │  80 │ 4.0.0               │ Jakarta XML Binding API
55 │ Active │  80 │ 0.18.0.202308011904 │ Jollyday Core
56 │ Active │  80 │ 0.18.0.202308011904 │ Jollyday with Jakarta XML Binding (JAXB)


karaf@root()> bundle:list -s
START LEVEL 100 , List Threshold: 50
ID │ State  │ Lvl │ Version             │ Symbolic name
───┼────────┼─────┼─────────────────────┼─────────────────────────────────────────
32 │ Active │  80 │ 4.4.4.SNAPSHOT      │ org.apache.karaf.event
52 │ Active │  80 │ 1.7.2               │ org.threeten.extra
53 │ Active │  80 │ 2.1.2               │ jakarta.activation-api
54 │ Active │  80 │ 4.0.0               │ jakarta.xml.bind-api
55 │ Active │  80 │ 0.18.0.202308011904 │ de.focus-shift.jollyday-core
56 │ Active │  80 │ 0.18.0.202308011904 │ de.focus-shift.jollyday-jaxb

```

Fixes #254


