### PR TITLE
Skip deployment of tests package to maven central

### DIFF
--- a/jollyday-tests/pom.xml
+++ b/jollyday-tests/pom.xml
@@ -77,4 +77,23 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.13</version>
+            <configuration>
+              <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
This is why 0.18.0 have not been released, because of javadoc and sources missing. Maybe the staging rules changed. On the other hand, the test package should not have been uploaded to maven central, now we skip it.