### PR TITLE
Add sources to holiday.xsd

### DIFF
--- a/jollyday-core/src/main/resources/focus_shift.de/jollyday/schema/holiday/holiday.xsd
+++ b/jollyday-core/src/main/resources/focus_shift.de/jollyday/schema/holiday/holiday.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        targetNamespace="https://focus_shift.de/jollyday/schema/holiday"
-        xmlns="https://focus_shift.de/jollyday/schema/holiday"
-        elementFormDefault="qualified">
+            targetNamespace="https://focus_shift.de/jollyday/schema/holiday"
+            xmlns="https://focus_shift.de/jollyday/schema/holiday"
+            elementFormDefault="qualified">
 
   <xsd:simpleType name="Weekday">
     <xsd:restriction base="xsd:string">
@@ -69,10 +69,25 @@
   <xsd:complexType name="Configuration">
     <xsd:sequence>
       <xsd:element name="Holidays" type="Holidays"/>
+      <xsd:element name="Sources" type="Sources" minOccurs="0"/>
       <xsd:element name="SubConfigurations" type="Configuration" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="hierarchy" type="xsd:string"/>
     <xsd:attribute name="description" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="Source">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="of" type="xsd:string"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="Sources">
+    <xsd:sequence>
+      <xsd:element name="Source" type="Source" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
   </xsd:complexType>
 
   <xsd:complexType name="Fixed">

--- a/jollyday-core/src/main/resources/holidays/Holidays_de.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_de.xml
@@ -30,6 +30,11 @@
     <ChristianHoliday type="WHIT_MONDAY" descriptionPropertiesKey="christian.WHIT_MONDAY"/>
   </Holidays>
 
+  <Sources>
+    <Source>https://en.wikipedia.org/wiki/Public_holidays_in_Germany</Source>
+    <Source of="ISO 3166-2">https://en.wikipedia.org/wiki/ISO_3166-2:DE</Source>
+  </Sources>
+
   <SubConfigurations hierarchy="be" description="Berlin">
     <Holidays>
       <Fixed month="MARCH" day="8" descriptionPropertiesKey="INTERNATIONAL_WOMAN" validFrom="2019"/>


### PR DESCRIPTION
closes #329

now you can add e.g.

```xml
  <Sources>
    <Source>https://de.wikipedia.org/wiki/Gesetzliche_Feiertage_in_Deutschland</Source>
    <Source>https://de.wikipedia.org/wiki/ISO_3166-2:DE</Source>
  </Sources>
```

so that it is clear from where the information about the countries public holidays are from. 