### PR TITLE
Fix British Overseas Territories

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_bm.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_bm.xml
@@ -6,8 +6,8 @@
                xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
   <Holidays>
     <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR">
-      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
+      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
 
     <!-- https://www.gov.bm/theofficialgazette/notices/gn03142023 -->
@@ -18,7 +18,6 @@
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
-
     <!-- 2019 it was moved one week earlier -->
     <Fixed month="MAY" day="24" validFrom="2019" validTo="2019" descriptionPropertiesKey="BERMUDA_DAY"/>
 
@@ -38,9 +37,9 @@
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY">
+      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
       <MovingCondition substitute="MONDAY" with="NEXT" weekday="TUESDAY"/>
-      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
 
     <FixedWeekday which="LAST" weekday="FRIDAY" month="MAY" validFrom="2018" validTo="2018" descriptionPropertiesKey="BERMUDA_DAY"/>
@@ -52,29 +51,25 @@
 
     <FixedWeekday which="THIRD" weekday="MONDAY" month="JUNE" validFrom="2009" descriptionPropertiesKey="NATIONAL_HEROES_DAY"/>
 
-    <!-- the Thursday before the first Monday in August -->
-
-    <!-- information for pre-2016 and post-2025 will very likely be very inaccurate, as just assumed to be the same all along -->
-    <FixedWeekday which="LAST" weekday="THURSDAY" month="JULY" validFrom="1947" validTo="2016" descriptionPropertiesKey="EMANCIPATION_DAY"/>
-    <FixedWeekday which="FIRST" weekday="THURSDAY" month="AUGUST" validFrom="2017" validTo="2019" descriptionPropertiesKey="EMANCIPATION_DAY"/>
-    <FixedWeekday which="LAST" weekday="THURSDAY" month="JULY" validFrom="2020" validTo="2022" descriptionPropertiesKey="EMANCIPATION_DAY"/>
-    <FixedWeekday which="FIRST" weekday="THURSDAY" month="AUGUST" validFrom="2023" validTo="2024" descriptionPropertiesKey="EMANCIPATION_DAY"/>
-    <FixedWeekday which="LAST" weekday="THURSDAY" month="JULY" validFrom="2025" descriptionPropertiesKey="EMANCIPATION_DAY"/>
-
-    <!-- the Friday before the first Monday in August -->
-
-    <!-- information for pre-2016 will very likely be very inaccurate, as just assumed to be the same all along -->
-    <FixedWeekday which="LAST" weekday="FRIDAY" month="JULY" validFrom="1947" validTo="2016" descriptionPropertiesKey="SOMERS_DAY"/>
-    <FixedWeekday which="FIRST" weekday="FRIDAY" month="AUGUST" validFrom="2017" validTo="2019" descriptionPropertiesKey="SOMERS_DAY"/>
-
-    <!-- the Friday before the first Monday in August -->
-
-    <!-- information for post-2025 will very likely be very inaccurate, as just assumed to be the same all along -->
-    <FixedWeekday which="LAST" weekday="FRIDAY" month="JULY" validFrom="2020" validTo="2022" descriptionPropertiesKey="MARY_PRINCE_DAY"/>
-    <FixedWeekday which="FIRST" weekday="FRIDAY" month="AUGUST" validFrom="2023" descriptionPropertiesKey="MARY_PRINCE_DAY"/>
-
     <FixedWeekday which="FIRST" weekday="MONDAY" month="SEPTEMBER" descriptionPropertiesKey="LABOUR_DAY"/>
 
     <ChristianHoliday type="GOOD_FRIDAY" descriptionPropertiesKey="christian.GOOD_FRIDAY"/>
+
+    <!-- the Thursday before the first Monday in August -->
+    <FixedWeekdayBetweenFixed weekday="THURSDAY" validFrom="1947" descriptionPropertiesKey="EMANCIPATION_DAY">
+      <from month="JULY" day="28"/>
+      <to month="AUGUST" day="3"/>
+    </FixedWeekdayBetweenFixed>
+
+    <!-- the Friday before the first Monday in August -->
+    <FixedWeekdayBetweenFixed weekday="FRIDAY" validFrom="1947" validTo="2019" descriptionPropertiesKey="SOMERS_DAY">
+      <from month="JULY" day="29"/>
+      <to month="AUGUST" day="4"/>
+    </FixedWeekdayBetweenFixed>
+    <!-- the Friday before the first Monday in August -->
+    <FixedWeekdayBetweenFixed weekday="FRIDAY" validFrom="2020" descriptionPropertiesKey="MARY_PRINCE_DAY">
+      <from month="JULY" day="29"/>
+      <to month="AUGUST" day="4"/>
+    </FixedWeekdayBetweenFixed>
   </Holidays>
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_bm.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_bm.xml
@@ -32,11 +32,30 @@
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
 
-    <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS">
+    <!-- assume that 2016 was an outlier -->
+    <Fixed month="DECEMBER" day="25" validTo="2015" descriptionPropertiesKey="CHRISTMAS">
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
-    <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY">
+    <Fixed month="DECEMBER" day="25" validFrom="2016" validTo="2016" descriptionPropertiesKey="CHRISTMAS">
+      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
+      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
+    </Fixed>
+    <Fixed month="DECEMBER" day="25" validFrom="2017" descriptionPropertiesKey="CHRISTMAS">
+      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
+      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
+    </Fixed>
+    <!-- assume that 2016 was an outlier -->
+    <Fixed month="DECEMBER" day="26" validTo="2015" descriptionPropertiesKey="BOXING_DAY">
+      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
+      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
+      <MovingCondition substitute="MONDAY" with="NEXT" weekday="TUESDAY"/>
+    </Fixed>
+    <Fixed month="DECEMBER" day="26" validFrom="2016" validTo="2016" descriptionPropertiesKey="BOXING_DAY">
+      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
+      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
+    </Fixed>
+    <Fixed month="DECEMBER" day="26" validFrom="2017" descriptionPropertiesKey="BOXING_DAY">
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
       <MovingCondition substitute="MONDAY" with="NEXT" weekday="TUESDAY"/>

--- a/jollyday-core/src/main/resources/holidays/Holidays_ky.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_ky.xml
@@ -31,9 +31,9 @@
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY">
+      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
       <MovingCondition substitute="MONDAY" with="NEXT" weekday="TUESDAY"/>
-      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
 
     <FixedWeekday which="FOURTH" weekday="MONDAY" month="JANUARY" descriptionPropertiesKey="NATIONAL_HEROES_DAY"/>
@@ -47,7 +47,6 @@
 
     <!-- The Public Holiday Act 2007 sets out the Sovereign’s official birthday celebration as “The Monday following the
     Saturday appointed in the United Kingdom as the official birthday of the reigning sovereign”. -->
-
     <!-- information for pre-2008 will very likely be very inaccurate, as just assumed to be the same since the accession of Elizabeth II -->
     <FixedWeekday which="THIRD" weekday="MONDAY" month="JUNE" validFrom="1952" validTo="2009" descriptionPropertiesKey="QUEENS_BIRTHDAY"/>
     <FixedWeekday which="SECOND" weekday="MONDAY" month="JUNE" validFrom="2010" validTo="2011" descriptionPropertiesKey="QUEENS_BIRTHDAY"/>

--- a/jollyday-core/src/main/resources/holidays/Holidays_vg.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_vg.xml
@@ -85,20 +85,23 @@
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
     </Fixed>
+    <Fixed month="DECEMBER" day="25" validFrom="2016" validTo="2016" descriptionPropertiesKey="CHRISTMAS">
+      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
+      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
+    </Fixed>
+    <Fixed month="DECEMBER" day="25" validFrom="2017" descriptionPropertiesKey="CHRISTMAS">
+      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
+      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
+    </Fixed>
     <!-- assume that 2016 was an outlier -->
     <Fixed month="DECEMBER" day="26" validTo="2015" descriptionPropertiesKey="BOXING_DAY">
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
     </Fixed>
-    <Fixed month="DECEMBER" day="25" validFrom="2016" validTo="2016" descriptionPropertiesKey="CHRISTMAS">
-      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
-    </Fixed>
     <Fixed month="DECEMBER" day="26" validFrom="2016" validTo="2016" descriptionPropertiesKey="BOXING_DAY">
-      <MovingCondition substitute="MONDAY" with="NEXT" weekday="TUESDAY"/>
-    </Fixed>
-    <Fixed month="DECEMBER" day="25" validFrom="2017" descriptionPropertiesKey="CHRISTMAS">
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
+      <MovingCondition substitute="MONDAY" with="NEXT" weekday="TUESDAY"/>
     </Fixed>
     <Fixed month="DECEMBER" day="26" validFrom="2017" descriptionPropertiesKey="BOXING_DAY">
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayBMTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayBMTest.java
@@ -24,7 +24,7 @@ class HolidayBMTest extends AbstractCountryTestBase {
   private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @ParameterizedTest
-  @ValueSource(ints = {2017, 2018, 2020, 2021, 2022, 2023, 2024, 2025})
+  @ValueSource(ints = {2015, 2016, 2017, 2018, 2020, 2021, 2022, 2023, 2024, 2025})
   void testManagerBMStructure(final int year) {
     validateCalendarData(ISO_CODE, year, true);
   }

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_bm_2015.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_bm_2015.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration hierarchy="bm" description="Bermuda"
+               xmlns="https://focus_shift.de/jollyday/schema/holiday"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
+  <Holidays>
+    <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
+    <Fixed month="APRIL" day="3" descriptionPropertiesKey="christian.GOOD_FRIDAY"/>
+    <Fixed month="MAY" day="25" descriptionPropertiesKey="BERMUDA_DAY"/>
+    <Fixed month="JUNE" day="15" descriptionPropertiesKey="NATIONAL_HEROES_DAY"/>
+    <Fixed month="JULY" day="30" descriptionPropertiesKey="EMANCIPATION_DAY"/>
+    <Fixed month="JULY" day="31" descriptionPropertiesKey="SOMERS_DAY"/>
+    <Fixed month="SEPTEMBER" day="7" descriptionPropertiesKey="LABOUR_DAY"/>
+    <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+    <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+    <Fixed month="DECEMBER" day="28" descriptionPropertiesKey="BOXING_DAY"/>
+  </Holidays>
+  <Sources>
+    <Source>https://en.wikipedia.org/wiki/Public_holidays_in_Bermuda</Source>
+  </Sources>
+</Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_bm_2016.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_bm_2016.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration hierarchy="bm" description="Bermuda"
+               xmlns="https://focus_shift.de/jollyday/schema/holiday"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
+  <Holidays>
+    <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
+    <Fixed month="MARCH" day="25" descriptionPropertiesKey="christian.GOOD_FRIDAY"/>
+    <Fixed month="MAY" day="24" descriptionPropertiesKey="BERMUDA_DAY"/>
+    <Fixed month="JUNE" day="20" descriptionPropertiesKey="NATIONAL_HEROES_DAY"/>
+    <Fixed month="JULY" day="28" descriptionPropertiesKey="EMANCIPATION_DAY"/>
+    <Fixed month="JULY" day="29" descriptionPropertiesKey="SOMERS_DAY"/>
+    <Fixed month="SEPTEMBER" day="5" descriptionPropertiesKey="LABOUR_DAY"/>
+    <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+    <Fixed month="DECEMBER" day="27" descriptionPropertiesKey="CHRISTMAS"/>
+    <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
+  </Holidays>
+</Configuration>


### PR DESCRIPTION
 🐞 fix moving of December holidays in Bermuda
 🐞 fix definitions for some Bermuda holidays using `FixedWeekdayBetweenFixed` as a workaround for missing `FixedWeekdayRelativeToWeekday`
 🎁 unify definition of holidays
 🎁 added more Bermuda test cases (though 2015 is just based on Wikipedia, as no official data could be found and the 2016 is only based on a single Archive.org snapshot and these tests should therefore be considered with less confidence, but the data does make sense).

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
