### PR TITLE
Add missing OSGi SPI headers

### DIFF
--- a/jollyday-core/pom.xml
+++ b/jollyday-core/pom.xml
@@ -85,6 +85,7 @@
           <instructions>
             <Bundle-SymbolicName>de.focus_shift.jollyday-core</Bundle-SymbolicName>
             <Export-Package>de.focus_shift.jollyday.core.*</Export-Package>
+            <Require-Capability>osgi.serviceloader;filter:="(osgi.serviceloader=de.focus_shift.jollyday.core.spi.ConfigurationService)";cardinality:=multiple,osgi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)"</Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/jollyday-jackson/pom.xml
+++ b/jollyday-jackson/pom.xml
@@ -73,6 +73,8 @@
           <instructions>
             <Bundle-SymbolicName>de.focus_shift.jollyday-jackson</Bundle-SymbolicName>
             <Export-Package>de.focus_shift.jackson.*</Export-Package>
+            <Require-Capability>osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+            <Provide-Capability>osgi.serviceloader;osgi.serviceloader=de.focus_shift.jollyday.core.spi.ConfigurationService</Provide-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/jollyday-jaxb/pom.xml
+++ b/jollyday-jaxb/pom.xml
@@ -90,6 +90,8 @@
           <instructions>
             <Bundle-SymbolicName>de.focus_shift.jollyday-jaxb</Bundle-SymbolicName>
             <Export-Package>de.focus_shift.jollyday.jaxb.*</Export-Package>
+            <Require-Capability>osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+            <Provide-Capability>osgi.serviceloader;osgi.serviceloader=de.focus_shift.jollyday.core.spi.ConfigurationService</Provide-Capability>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
This adds the required headers for using SPI with OSGi.

See: https://aries.apache.org/documentation/modules/spi-fly.html