### PR TITLE
Static Utils

### DIFF
--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/CalendarHierarchy.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/CalendarHierarchy.java
@@ -16,7 +16,6 @@ public class CalendarHierarchy {
   private final String id;
   private Map<String, CalendarHierarchy> children = new HashMap<>();
   private final CalendarHierarchy parent;
-  private final ResourceUtil resourceUtil = new ResourceUtil();
   private String fallbackDescription;
 
   /**
@@ -58,7 +57,7 @@ public class CalendarHierarchy {
    * @return Description text
    */
   public String getDescription(Locale l) {
-    String descr = resourceUtil.getCountryDescription(l, getPropertiesKey());
+    String descr = ResourceUtil.getCountryDescription(l, getPropertiesKey());
     if (ResourceUtil.UNDEFINED.equals(descr) && fallbackDescription != null) {
       descr = fallbackDescription;
     }

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/Holiday.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/Holiday.java
@@ -30,10 +30,6 @@ public final class Holiday implements Comparable<Holiday> {
    * The type of holiday. e.g. official holiday or not.
    */
   private final HolidayType type;
-  /**
-   * Utility for accessing resources.
-   */
-  private final ResourceUtil resourceUtil = new ResourceUtil();
 
   /**
    * Constructs a holiday for a date using the provided properties key to
@@ -78,7 +74,7 @@ public final class Holiday implements Comparable<Holiday> {
    * @return Description for this holiday
    */
   public String getDescription() {
-    return resourceUtil.getHolidayDescription(Locale.getDefault(), getPropertiesKey());
+    return ResourceUtil.getHolidayDescription(Locale.getDefault(), getPropertiesKey());
   }
 
   /**
@@ -88,7 +84,7 @@ public final class Holiday implements Comparable<Holiday> {
    * @return Description for this holiday
    */
   public String getDescription(Locale locale) {
-    return resourceUtil.getHolidayDescription(locale, getPropertiesKey());
+    return ResourceUtil.getHolidayDescription(locale, getPropertiesKey());
   }
 
   @Override

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/HolidayManager.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/HolidayManager.java
@@ -56,10 +56,7 @@ public abstract class HolidayManager {
    * the holiday cache
    */
   private final Cache<Set<Holiday>> holidayCache = new Cache<>();
-  /**
-   * Utility for calendar operations
-   */
-  protected final CalendarUtil calendarUtil = new CalendarUtil();
+
   /**
    * The datasource to get the holiday data from.
    */
@@ -205,7 +202,7 @@ public abstract class HolidayManager {
         return getHolidays(c.getYear(), args);
       }
     });
-    return calendarUtil.contains(holidays, c, holidayType);
+    return CalendarUtil.contains(holidays, c, holidayType);
   }
 
   /**

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/caching/HolidayManagerValueHandler.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/caching/HolidayManagerValueHandler.java
@@ -15,11 +15,6 @@ public class HolidayManagerValueHandler implements Cache.ValueHandler<HolidayMan
   private final String managerImplClassName;
   private final ConfigurationServiceManager configurationServiceManager;
 
-  /**
-   * Utility to load classes.
-   */
-  private final ClassLoadingUtil classLoadingUtil = new ClassLoadingUtil();
-
   public HolidayManagerValueHandler(final ManagerParameter parameter, final String managerImplClassName, final ConfigurationServiceManager configurationServiceManager) {
     this.parameter = parameter;
     this.managerImplClassName = managerImplClassName;
@@ -50,7 +45,7 @@ public class HolidayManagerValueHandler implements Cache.ValueHandler<HolidayMan
    */
   private HolidayManager instantiateManagerImpl(String managerImplClassName) {
     try {
-      final Class<?> managerImplClass = classLoadingUtil.loadClass(managerImplClassName);
+      final Class<?> managerImplClass = ClassLoadingUtil.loadClass(managerImplClassName);
       return (HolidayManager) managerImplClass.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new IllegalStateException("Cannot create manager class " + managerImplClassName, e);

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/configuration/ClasspathConfigurationProvider.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/configuration/ClasspathConfigurationProvider.java
@@ -14,8 +14,6 @@ import java.util.Properties;
  */
 class ClasspathConfigurationProvider implements ConfigurationProvider {
 
-  private final ResourceUtil resourceUtil = new ResourceUtil();
-
   private static final String DEFAULT_CONFIGURATION_FILE_NAME = "jollyday.properties";
   private URL configurationFile;
 
@@ -45,7 +43,7 @@ class ClasspathConfigurationProvider implements ConfigurationProvider {
   }
 
   private URL getConfigurationFile(final String configurationFileName) {
-    final URL configuration = resourceUtil.getResource(configurationFileName);
+    final URL configuration = ResourceUtil.getResource(configurationFileName);
     if (configuration == null) {
       throw new IllegalStateException("Configuration file '" + configurationFileName + "' not found on classpath.");
     }

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/configuration/ConfigurationProviderManager.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/configuration/ConfigurationProviderManager.java
@@ -14,7 +14,6 @@ public class ConfigurationProviderManager {
 
   private ConfigurationProvider classpathConfigurationProvider = new ClasspathConfigurationProvider();
   private ConfigurationProvider urlConfigurationProvider = new URLConfigurationProvider();
-  private final ClassLoadingUtil classLoadingUtil = new ClassLoadingUtil();
 
   /**
    * Reads the jollyday configuration from the
@@ -42,7 +41,7 @@ public class ConfigurationProviderManager {
         if (providerClassName == null || providerClassName.isEmpty())
           continue;
         try {
-          final Class<?> providerClass = Class.forName(providerClassName.trim(), true, classLoadingUtil.getClassloader());
+          final Class<?> providerClass = Class.forName(providerClassName.trim(), true, ClassLoadingUtil.getClassloader());
           final ConfigurationProvider configurationProvider = (ConfigurationProvider) providerClass.getDeclaredConstructor().newInstance();
           parameter.mergeProperties(configurationProvider.getProperties());
         } catch (Exception e) {

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/DefaultHolidayManager.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/DefaultHolidayManager.java
@@ -45,10 +45,6 @@ public class DefaultHolidayManager extends HolidayManager {
    * Configuration parsed on initialization.
    */
   protected Configuration configuration;
-  /**
-   * Utility class to handle class loading
-   */
-  private final ClassLoadingUtil classLoadingUtil = new ClassLoadingUtil();
 
   /**
    * {@inheritDoc}
@@ -180,7 +176,7 @@ public class DefaultHolidayManager extends HolidayManager {
       final String propName = PARSER_IMPL_PREFIX + className;
       final String parserClassName = getManagerParameter().getProperty(propName);
       if (parserClassName != null) {
-        final Class<?> parserClass = classLoadingUtil.loadClass(parserClassName);
+        final Class<?> parserClass = ClassLoadingUtil.loadClass(parserClassName);
         holidayParser = (HolidayParser) parserClass.getConstructor().newInstance();
         parserCache.put(className, holidayParser);
       }

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/JapaneseHolidayManager.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/JapaneseHolidayManager.java
@@ -2,6 +2,7 @@ package de.focus_shift.jollyday.core.impl;
 
 import de.focus_shift.jollyday.core.Holiday;
 import de.focus_shift.jollyday.core.HolidayType;
+import de.focus_shift.jollyday.core.util.CalendarUtil;
 
 import java.time.LocalDate;
 import java.util.HashSet;
@@ -11,9 +12,6 @@ import java.util.Set;
  * <p>
  * JapaneseHolidayManager class.
  * </p>
- *
- * @author Sven
- * @version $Id: $
  */
 public class JapaneseHolidayManager extends DefaultHolidayManager {
 
@@ -34,7 +32,7 @@ public class JapaneseHolidayManager extends DefaultHolidayManager {
     final Set<Holiday> additionalHolidays = new HashSet<>();
     for (Holiday holiday : holidays) {
       final LocalDate twoDaysLater = holiday.getDate().plusDays(2);
-      if (calendarUtil.contains(holidays, twoDaysLater)) {
+      if (CalendarUtil.contains(holidays, twoDaysLater)) {
         final LocalDate bridgingDate = twoDaysLater.minusDays(1);
         additionalHolidays.add(new Holiday(bridgingDate, BRIDGING_HOLIDAY_PROPERTIES_KEY, HolidayType.OFFICIAL_HOLIDAY));
       }

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/parameter/CalendarPartManagerParameter.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/parameter/CalendarPartManagerParameter.java
@@ -10,7 +10,6 @@ public class CalendarPartManagerParameter extends BaseManagerParameter {
   private static final String FILE_PREFIX = "holidays/Holidays";
   private static final String FILE_SUFFIX = ".xml";
 
-  private final ResourceUtil resourceUtil = new ResourceUtil();
 
   private final String calendarPart;
 
@@ -32,7 +31,7 @@ public class CalendarPartManagerParameter extends BaseManagerParameter {
   @Override
   public URL createResourceUrl() {
     final String configurationFileName = getConfigurationFileName(calendarPart);
-    return resourceUtil.getResource(configurationFileName);
+    return ResourceUtil.getResource(configurationFileName);
   }
 
   @Override

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/CalendarUtil.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/CalendarUtil.java
@@ -22,18 +22,19 @@ import static java.time.Month.JANUARY;
 
 /**
  * Utility class for date operations.
- *
- * @author Sven Diedrichsen
- * @version $Id: $
  */
 public class CalendarUtil {
+
+  private CalendarUtil() {
+    // ok
+  }
 
   /**
    * Creates the current date within the gregorian calendar.
    *
    * @return today
    */
-  public LocalDate create() {
+  public static LocalDate create() {
     return LocalDate.now();
   }
 
@@ -45,7 +46,7 @@ public class CalendarUtil {
    * @param day   a int.
    * @return date
    */
-  public LocalDate create(int year, int month, int day) {
+  public static LocalDate create(int year, int month, int day) {
     return LocalDate.of(year, month, day);
   }
 
@@ -58,7 +59,7 @@ public class CalendarUtil {
    * @param chronology the chronology to use
    * @return date the {@link LocalDate}
    */
-  public ChronoLocalDate create(int year, int month, int day, Chronology chronology) {
+  public static ChronoLocalDate create(int year, int month, int day, Chronology chronology) {
     return chronology.date(year, month, day);
   }
 
@@ -68,7 +69,7 @@ public class CalendarUtil {
    * @param date a {@link LocalDate} object.
    * @return is weekend
    */
-  public boolean isWeekend(final LocalDate date) {
+  public static boolean isWeekend(final LocalDate date) {
     return date.getDayOfWeek() == SATURDAY || date.getDayOfWeek() == SUNDAY;
   }
 
@@ -84,7 +85,7 @@ public class CalendarUtil {
    * @param islamicDay    a int.
    * @return List of gregorian dates for the islamic month/day.
    */
-  public Stream<LocalDate> getIslamicHolidaysInGregorianYear(int gregorianYear, int islamicMonth, int islamicDay) {
+  public static Stream<LocalDate> getIslamicHolidaysInGregorianYear(int gregorianYear, int islamicMonth, int islamicDay) {
     return getDatesFromChronologyWithinGregorianYear(islamicMonth, islamicDay, gregorianYear, HijrahChronology.INSTANCE);
   }
 
@@ -101,7 +102,7 @@ public class CalendarUtil {
    * @param relativeShift a int.
    * @return List of gregorian dates for the islamic month/day shifted by relative shift days.
    */
-  public Set<LocalDate> getRelativeIslamicHolidaysInGregorianYear(int gregorianYear, int islamicMonth, int islamicDay, int relativeShift) {
+  public static Set<LocalDate> getRelativeIslamicHolidaysInGregorianYear(int gregorianYear, int islamicMonth, int islamicDay, int relativeShift) {
     return getRelativeDatesFromChronologyWithinGregorianYear(islamicMonth, islamicDay, gregorianYear,
       HijrahChronology.INSTANCE, relativeShift);
   }
@@ -117,7 +118,7 @@ public class CalendarUtil {
    * @param eoDay         a int.
    * @return List of gregorian dates for the ethiopian orthodox month/day.
    */
-  public Stream<LocalDate> getEthiopianOrthodoxHolidaysInGregorianYear(int gregorianYear, int eoMonth, int eoDay) {
+  public static Stream<LocalDate> getEthiopianOrthodoxHolidaysInGregorianYear(int gregorianYear, int eoMonth, int eoDay) {
 
     return getDatesFromChronologyWithinGregorianYear(eoMonth, eoDay, gregorianYear, CopticChronology.INSTANCE);
   }
@@ -132,7 +133,7 @@ public class CalendarUtil {
    * @param targetChrono
    * @return the list of gregorian dates.
    */
-  private Stream<LocalDate> getDatesFromChronologyWithinGregorianYear(int targetMonth, int targetDay, int gregorianYear, Chronology targetChrono) {
+  private static Stream<LocalDate> getDatesFromChronologyWithinGregorianYear(int targetMonth, int targetDay, int gregorianYear, Chronology targetChrono) {
     return new CalculateRelativeDatesFromChronologyWithinGregorianYear(targetMonth, targetDay, targetChrono, 0).apply(gregorianYear);
   }
 
@@ -147,8 +148,8 @@ public class CalendarUtil {
    * @param relativeShift
    * @return the list of gregorian dates.
    */
-  private Set<LocalDate> getRelativeDatesFromChronologyWithinGregorianYear(int targetMonth, int targetDay,
-                                                                           int gregorianYear, Chronology targetChrono, int relativeShift) {
+  private static Set<LocalDate> getRelativeDatesFromChronologyWithinGregorianYear(int targetMonth, int targetDay,
+                                                                                  int gregorianYear, Chronology targetChrono, int relativeShift) {
     int absoluteShift = Math.abs(relativeShift);
     Set<LocalDate> holidays = new HashSet<>();
     LocalDate firstGregorianDate = LocalDate.of(gregorianYear, JANUARY, 1);
@@ -179,7 +180,7 @@ public class CalendarUtil {
    * @param holidayType a {@link HolidayType} object
    * @return contains this date
    */
-  public boolean contains(final Set<Holiday> holidays, final LocalDate date, final HolidayType holidayType) {
+  public static boolean contains(final Set<Holiday> holidays, final LocalDate date, final HolidayType holidayType) {
     return holidays.stream().anyMatch(h -> h.getDate().equals(date) && (holidayType == null || h.getType() == holidayType));
   }
 
@@ -190,8 +191,7 @@ public class CalendarUtil {
    * @param date     the date to look for
    * @return the date is contained in the set of holidays
    */
-  public boolean contains(final Set<Holiday> holidays, final LocalDate date) {
+  public static boolean contains(final Set<Holiday> holidays, final LocalDate date) {
     return contains(holidays, date, null);
   }
-
 }

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/ClassLoadingUtil.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/ClassLoadingUtil.java
@@ -8,11 +8,12 @@ import org.slf4j.LoggerFactory;
  * <p>
  * ClassLoadingUtil class.
  * </p>
- *
- * @author José Pedro Pereira - Linkare TI
- * @version $Id: $
  */
 public class ClassLoadingUtil {
+
+  private ClassLoadingUtil() {
+    // ok
+  }
 
   private static final Logger LOG = LoggerFactory.getLogger(ClassLoadingUtil.class);
 
@@ -25,7 +26,7 @@ public class ClassLoadingUtil {
    * @return a {@link java.lang.Class} object.
    * @throws java.lang.ClassNotFoundException if any.
    */
-  public Class<?> loadClass(String className) throws ClassNotFoundException {
+  public static Class<?> loadClass(String className) throws ClassNotFoundException {
     try {
       return Class.forName(className, true, getClassloader());
     } catch (Exception e) {
@@ -40,7 +41,7 @@ public class ClassLoadingUtil {
    * @return the current threads context classloader
    * @see Thread#currentThread()
    */
-  public ClassLoader getClassloader() {
+  public static ClassLoader getClassloader() {
     return Thread.currentThread().getContextClassLoader();
   }
 }

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/ResourceUtil.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/ResourceUtil.java
@@ -43,10 +43,6 @@ public class ResourceUtil {
    * Cache for the country descriptions resource bundles.
    */
   private static final Map<Locale, ResourceBundle> COUNTRY_DESCRIPTIONS_CACHE = new ConcurrentHashMap<>();
-  /**
-   * Util class to provide the correct classloader.
-   */
-  private final ClassLoadingUtil classLoadingUtil = new ClassLoadingUtil();
 
   /**
    * The description read with the default locale.
@@ -139,7 +135,7 @@ public class ResourceUtil {
    * @return ResourceBundle containing the descriptions for the locale.
    */
   private ResourceBundle getResourceBundle(Locale locale, Map<Locale, ResourceBundle> resourceCache, String filePrefix) {
-    return resourceCache.computeIfAbsent(locale, givenLocale -> getBundle(filePrefix, givenLocale, classLoadingUtil.getClassloader()));
+    return resourceCache.computeIfAbsent(locale, givenLocale -> getBundle(filePrefix, givenLocale, ClassLoadingUtil.getClassloader()));
   }
 
   /**
@@ -150,7 +146,7 @@ public class ResourceUtil {
    */
   public URL getResource(String resourceName) {
     try {
-      final URL resource = classLoadingUtil.getClassloader().getResource(resourceName);
+      final URL resource = ClassLoadingUtil.getClassloader().getResource(resourceName);
       return resource == null ? this.getClass().getClassLoader().getResource(resourceName) : resource;
     } catch (Exception e) {
       throw new IllegalStateException("Cannot load resource: " + resourceName, e);

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/ResourceUtil.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/ResourceUtil.java
@@ -14,6 +14,11 @@ import static java.util.ResourceBundle.getBundle;
  * TODO improve javadoc
  */
 public class ResourceUtil {
+
+  private ResourceUtil() {
+    // ok
+  }
+
   /**
    * Property prefix for country descriptions.
    */
@@ -50,7 +55,7 @@ public class ResourceUtil {
    * @param key a {@link java.lang.String} object.
    * @return holiday description using default locale.
    */
-  public String getHolidayDescription(String key) {
+  public static String getHolidayDescription(String key) {
     return getHolidayDescription(Locale.getDefault(), key);
   }
 
@@ -61,7 +66,7 @@ public class ResourceUtil {
    * @param key    a {@link java.lang.String} object.
    * @return holiday description using the provided locale.
    */
-  public String getHolidayDescription(Locale locale, String key) {
+  public static String getHolidayDescription(Locale locale, String key) {
     return getDescription(HOLIDAY_PROPERTY_PREFIX + "." + key, getHolidayDescriptions(locale));
   }
 
@@ -73,7 +78,7 @@ public class ResourceUtil {
    * @param key a {@link java.lang.String} object.
    * @return the description
    */
-  public String getCountryDescription(String key) {
+  public static String getCountryDescription(String key) {
     return getCountryDescription(Locale.getDefault(), key);
   }
 
@@ -84,7 +89,7 @@ public class ResourceUtil {
    * @param key a {@link java.lang.String} object.
    * @return Description text
    */
-  public String getCountryDescription(Locale l, String key) {
+  public static String getCountryDescription(Locale l, String key) {
     if (key != null) {
       return getDescription(COUNTRY_PROPERTY_PREFIX + "." + key.toLowerCase(), getCountryDescriptions(l));
     }
@@ -99,7 +104,7 @@ public class ResourceUtil {
    * @param bundle the bundle to get the description
    * @return description the description behind the key
    */
-  private String getDescription(String key, final ResourceBundle bundle) {
+  private static String getDescription(String key, final ResourceBundle bundle) {
     if (!bundle.containsKey(key)) {
       return UNDEFINED;
     }
@@ -113,7 +118,7 @@ public class ResourceUtil {
    * @param locale Locale to retrieve the descriptions for.
    * @return ResourceBundle containing the descriptions for the locale.
    */
-  private ResourceBundle getHolidayDescriptions(Locale locale) {
+  private static ResourceBundle getHolidayDescriptions(Locale locale) {
     return getResourceBundle(locale, HOLIDAY_DESCRIPTION_CACHE, HOLIDAY_DESCRIPTIONS_FILE_PREFIX);
   }
 
@@ -124,7 +129,7 @@ public class ResourceUtil {
    * @param locale Locale to retrieve the descriptions for.
    * @return ResourceBundle containing the descriptions for the locale.
    */
-  private ResourceBundle getCountryDescriptions(Locale locale) {
+  private static ResourceBundle getCountryDescriptions(Locale locale) {
     return getResourceBundle(locale, COUNTRY_DESCRIPTIONS_CACHE, COUNTRY_DESCRIPTIONS_FILE_PREFIX);
   }
 
@@ -134,7 +139,7 @@ public class ResourceUtil {
    * @param locale Locale to retrieve the descriptions for.
    * @return ResourceBundle containing the descriptions for the locale.
    */
-  private ResourceBundle getResourceBundle(Locale locale, Map<Locale, ResourceBundle> resourceCache, String filePrefix) {
+  private static ResourceBundle getResourceBundle(Locale locale, Map<Locale, ResourceBundle> resourceCache, String filePrefix) {
     return resourceCache.computeIfAbsent(locale, givenLocale -> getBundle(filePrefix, givenLocale, ClassLoadingUtil.getClassloader()));
   }
 
@@ -144,10 +149,9 @@ public class ResourceUtil {
    * @param resourceName the name/path of the resource to load
    * @return the URL to the resource
    */
-  public URL getResource(String resourceName) {
+  public static URL getResource(String resourceName) {
     try {
-      final URL resource = ClassLoadingUtil.getClassloader().getResource(resourceName);
-      return resource == null ? this.getClass().getClassLoader().getResource(resourceName) : resource;
+      return ClassLoadingUtil.getClassloader().getResource(resourceName);
     } catch (Exception e) {
       throw new IllegalStateException("Cannot load resource: " + resourceName, e);
     }

--- a/jollyday-core/src/test/java/de/focus_shift/jollyday/core/util/CalendarUtilTest.java
+++ b/jollyday-core/src/test/java/de/focus_shift/jollyday/core/util/CalendarUtilTest.java
@@ -18,18 +18,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CalendarUtilTest {
 
-  private final CalendarUtil sut = new CalendarUtil();
-
   @Test
   void testWeekend() {
     final LocalDate dateFriday = LocalDate.of(2010, MARCH, 12);
     final LocalDate dateSaturday = LocalDate.of(2010, MARCH, 13);
     final LocalDate dateSunday = LocalDate.of(2010, MARCH, 14);
     final LocalDate dateMonday = LocalDate.of(2010, MARCH, 15);
-    assertThat(sut.isWeekend(dateFriday)).isFalse();
-    assertThat(sut.isWeekend(dateSaturday)).isTrue();
-    assertThat(sut.isWeekend(dateSunday)).isTrue();
-    assertThat(sut.isWeekend(dateMonday)).isFalse();
+    assertThat(CalendarUtil.isWeekend(dateFriday)).isFalse();
+    assertThat(CalendarUtil.isWeekend(dateSaturday)).isTrue();
+    assertThat(CalendarUtil.isWeekend(dateSunday)).isTrue();
+    assertThat(CalendarUtil.isWeekend(dateMonday)).isFalse();
   }
 
   @Test
@@ -37,7 +35,7 @@ class CalendarUtilTest {
     final Set<LocalDate> expected = new HashSet<>();
     expected.add(LocalDate.of(2008, JANUARY, 10));
     expected.add(LocalDate.of(2008, DECEMBER, 29));
-    final Stream<LocalDate> holidays = sut.getIslamicHolidaysInGregorianYear(2008, 1, 1);
+    final Stream<LocalDate> holidays = CalendarUtil.getIslamicHolidaysInGregorianYear(2008, 1, 1);
 
     final Set<LocalDate> collect = holidays.collect(toSet());
     assertThat(collect)
@@ -49,7 +47,7 @@ class CalendarUtilTest {
   void testCalendarIslamicAschura2008() {
     final Set<LocalDate> expected = new HashSet<>();
     expected.add(LocalDate.of(2008, JANUARY, 19));
-    final Stream<LocalDate> holidays = sut.getIslamicHolidaysInGregorianYear(2008, 1, 10);
+    final Stream<LocalDate> holidays = CalendarUtil.getIslamicHolidaysInGregorianYear(2008, 1, 10);
 
     final Set<LocalDate> collect = holidays.collect(toSet());
     assertThat(collect)
@@ -62,7 +60,7 @@ class CalendarUtilTest {
     final Set<LocalDate> expected = new HashSet<>();
     expected.add(LocalDate.of(2009, JANUARY, 7));
     expected.add(LocalDate.of(2009, DECEMBER, 27));
-    final Stream<LocalDate> holidays = sut.getIslamicHolidaysInGregorianYear(2009, 1, 10);
+    final Stream<LocalDate> holidays = CalendarUtil.getIslamicHolidaysInGregorianYear(2009, 1, 10);
 
     final Set<LocalDate> collect = holidays.collect(toSet());
     assertThat(collect)
@@ -74,7 +72,7 @@ class CalendarUtilTest {
   void testCalendarIslamicIdAlFitr2008() {
     final Set<LocalDate> expected = new HashSet<>();
     expected.add(LocalDate.of(2008, OCTOBER, 1));
-    final Stream<LocalDate> holidays = sut.getIslamicHolidaysInGregorianYear(2008, 10, 1);
+    final Stream<LocalDate> holidays = CalendarUtil.getIslamicHolidaysInGregorianYear(2008, 10, 1);
     final Set<LocalDate> collect = holidays.collect(toSet());
     assertThat(collect)
       .isEqualTo(expected)
@@ -85,7 +83,7 @@ class CalendarUtilTest {
   void testCalendarIslamicIdAlFitr2009() {
     final Set<LocalDate> expected = new HashSet<>();
     expected.add(LocalDate.of(2009, SEPTEMBER, 20));
-    final Stream<LocalDate> holidays = sut.getIslamicHolidaysInGregorianYear(2009, 10, 1);
+    final Stream<LocalDate> holidays = CalendarUtil.getIslamicHolidaysInGregorianYear(2009, 10, 1);
     final Set<LocalDate> collect = holidays.collect(toSet());
     assertThat(collect)
       .isEqualTo(expected)

--- a/jollyday-core/src/test/java/de/focus_shift/jollyday/core/util/ClassLoadingUtilTest.java
+++ b/jollyday-core/src/test/java/de/focus_shift/jollyday/core/util/ClassLoadingUtilTest.java
@@ -7,20 +7,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ClassLoadingUtilTest {
 
-  private final ClassLoadingUtil classLoadingUtil = new ClassLoadingUtil();
-
   @Test
   void testGetClassloader() {
-    assertThat(classLoadingUtil.getClassloader()).isEqualTo(Thread.currentThread().getContextClassLoader());
+    assertThat(ClassLoadingUtil.getClassloader()).isEqualTo(Thread.currentThread().getContextClassLoader());
   }
 
   @Test
   void testClassNotFound() {
-    assertThatThrownBy(() -> classLoadingUtil.loadClass("")).isInstanceOf(ClassNotFoundException.class);
+    assertThatThrownBy(() -> ClassLoadingUtil.loadClass("")).isInstanceOf(ClassNotFoundException.class);
   }
 
   @Test
   void testClassloadingCorrect() throws ClassNotFoundException {
-    assertThat(classLoadingUtil.loadClass(ClassLoadingUtil.class.getName())).isEqualTo(ClassLoadingUtil.class);
+    assertThat(ClassLoadingUtil.loadClass(ClassLoadingUtil.class.getName())).isEqualTo(ClassLoadingUtil.class);
   }
 }

--- a/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/ChristianHolidayParserTest.java
+++ b/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/ChristianHolidayParserTest.java
@@ -29,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ChristianHolidayParserTest {
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   private ChristianHolidayParser sut;
 
@@ -51,7 +50,7 @@ class ChristianHolidayParserTest {
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
     final Holiday easterDate = holidays.iterator().next();
-    final LocalDate ed = calendarUtil.create(2011, 4, 24);
+    final LocalDate ed = CalendarUtil.create(2011, 4, 24);
     assertThat(easterDate.getDate()).isEqualTo(ed);
   }
 
@@ -69,7 +68,7 @@ class ChristianHolidayParserTest {
     final RelativeToEasterSundayParser p = new RelativeToEasterSundayParser();
     final List<Holiday> holidays = p.parse(2011, new JacksonHolidays(config));
     final List<LocalDate> expected = new ArrayList<>();
-    expected.add(calendarUtil.create(2011, 4, 25));
+    expected.add(CalendarUtil.create(2011, 4, 25));
     assertThat(holidays).hasSameSizeAs(expected);
     assertThat(holidays.iterator().next().getDate()).isEqualTo(expected.get(0));
   }
@@ -80,13 +79,13 @@ class ChristianHolidayParserTest {
       GENERAL_PRAYER_DAY, PENTECOST, SACRED_HEART);
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
     final List<LocalDate> expected = new ArrayList<>();
-    expected.add(calendarUtil.create(2011, 3, 7));
-    expected.add(calendarUtil.create(2011, 4, 23));
-    expected.add(calendarUtil.create(2011, 4, 24));
-    expected.add(calendarUtil.create(2011, 4, 26));
-    expected.add(calendarUtil.create(2011, 5, 20));
-    expected.add(calendarUtil.create(2011, 6, 12));
-    expected.add(calendarUtil.create(2011, 7, 1));
+    expected.add(CalendarUtil.create(2011, 3, 7));
+    expected.add(CalendarUtil.create(2011, 4, 23));
+    expected.add(CalendarUtil.create(2011, 4, 24));
+    expected.add(CalendarUtil.create(2011, 4, 26));
+    expected.add(CalendarUtil.create(2011, 5, 20));
+    expected.add(CalendarUtil.create(2011, 6, 12));
+    expected.add(CalendarUtil.create(2011, 7, 1));
 
     assertThat(holidays).hasSameSizeAs(expected);
 
@@ -106,7 +105,7 @@ class ChristianHolidayParserTest {
     final List<Holiday> holidays = sut.parse(2019, new JacksonHolidays(config));
 
     final String expectedPropertiesKey = "CUSTOM_KEY";
-    final LocalDate expectedDate = calendarUtil.create(2019, 4, 23);
+    final LocalDate expectedDate = CalendarUtil.create(2019, 4, 23);
 
     assertThat(holidays).hasSize(1);
 

--- a/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/EthiopianOrthodoxHolidayParserTest.java
+++ b/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/EthiopianOrthodoxHolidayParserTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EthiopianOrthodoxHolidayParserTest {
 
   private final EthiopianOrthodoxHolidayParser sut = new EthiopianOrthodoxHolidayParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testEmpty() {
@@ -40,13 +39,13 @@ class EthiopianOrthodoxHolidayParserTest {
 
     final List<Holiday> holidays = sut.parse(2010, new JacksonHolidays(config));
     assertThat(holidays).hasSize(3);
-    assertContains(calendarUtil.create(2010, 1, 18), Sets.newHashSet(holidays));
-    assertContains(calendarUtil.create(2010, 9, 11), Sets.newHashSet(holidays));
-    assertContains(calendarUtil.create(2010, 9, 27), Sets.newHashSet(holidays));
+    assertContains(CalendarUtil.create(2010, 1, 18), Sets.newHashSet(holidays));
+    assertContains(CalendarUtil.create(2010, 9, 11), Sets.newHashSet(holidays));
+    assertContains(CalendarUtil.create(2010, 9, 27), Sets.newHashSet(holidays));
   }
 
   private void assertContains(LocalDate date, Set<Holiday> holidays) {
-    assertThat(calendarUtil.contains(holidays, date)).isTrue();
+    assertThat(CalendarUtil.contains(holidays, date)).isTrue();
   }
 
   private EthiopianOrthodoxHoliday createHoliday(EthiopianOrthodoxHolidayType type) {

--- a/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/FixedParserTest.java
+++ b/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/FixedParserTest.java
@@ -34,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FixedParserTest {
 
   private final FixedParser sut = new FixedParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testFixedWithValidity() {
@@ -45,7 +44,7 @@ class FixedParserTest {
     );
 
     final List<Holiday> holidays = sut.parse(2010, new JacksonHolidays(config));
-    containsAll(holidays, calendarUtil.create(2010, 1, 1), calendarUtil.create(2010, 3, 3));
+    containsAll(holidays, CalendarUtil.create(2010, 1, 1), CalendarUtil.create(2010, 3, 3));
   }
 
   @Test
@@ -56,7 +55,7 @@ class FixedParserTest {
     );
 
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
-    containsAll(holidays, calendarUtil.create(2011, 1, 7), calendarUtil.create(2011, 1, 24));
+    containsAll(holidays, CalendarUtil.create(2011, 1, 7), CalendarUtil.create(2011, 1, 24));
   }
 
   @Test

--- a/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/FixedWeekdayBetweenFixedParserTest.java
+++ b/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/FixedWeekdayBetweenFixedParserTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FixedWeekdayBetweenFixedParserTest extends FixedParserTest {
 
   private final FixedWeekdayBetweenFixedParser sut = new FixedWeekdayBetweenFixedParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testEmpty() {
@@ -51,6 +50,6 @@ class FixedWeekdayBetweenFixedParserTest extends FixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 1, 19));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 1, 19));
   }
 }

--- a/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/FixedWeekdayRelativeToFixedParserTest.java
+++ b/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/FixedWeekdayRelativeToFixedParserTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FixedWeekdayRelativeToFixedParserTest {
 
   private final FixedWeekdayRelativeToFixedParser sut = new FixedWeekdayRelativeToFixedParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testEmpty() {
@@ -65,7 +64,7 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 1, 24));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 1, 24));
   }
 
   @Test
@@ -84,7 +83,7 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 1, 17));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 1, 17));
   }
 
   @Test
@@ -104,7 +103,7 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 2, 14));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 2, 14));
   }
 
   @Test
@@ -124,7 +123,7 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 4, 12));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 4, 12));
   }
 
   @Test
@@ -144,7 +143,7 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2019, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2019, 6, 11));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2019, 6, 11));
   }
 
   @Test
@@ -165,39 +164,39 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2019, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2019, 6, 11));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2019, 6, 11));
   }
 
 /* TODO
   @Test
   void testClosestAdjusterSameMonth() {
     final TemporalAdjuster adjuster = FixedWeekdayRelativeToFixedParser.closest(DayOfWeek.MONDAY);
-    final LocalDate date = calendarUtil.create(2018, 12, 1); // Saturday
-    final LocalDate expectedDate = calendarUtil.create(2018, 12, 3); // Monday
+    final LocalDate date = CalendarUtil.create(2018, 12, 1); // Saturday
+    final LocalDate expectedDate = CalendarUtil.create(2018, 12, 3); // Monday
     assertEquals(expectedDate, date.with(adjuster));
   }
 
   @Test
   void testClosestAdjusterPreviousMonth() {
     final TemporalAdjuster adjuster = FixedWeekdayRelativeToFixedParser.closest(DayOfWeek.FRIDAY);
-    final LocalDate date = calendarUtil.create(2019, 6, 3); // Monday
-    final LocalDate expectedDate = calendarUtil.create(2019, 5, 31); // Friday
+    final LocalDate date = CalendarUtil.create(2019, 6, 3); // Monday
+    final LocalDate expectedDate = CalendarUtil.create(2019, 5, 31); // Friday
     assertEquals(expectedDate, date.with(adjuster));
   }
 
   @Test
   void testClosestAdjusterNextMonth() {
     final TemporalAdjuster adjuster = FixedWeekdayRelativeToFixedParser.closest(DayOfWeek.MONDAY);
-    final LocalDate date = calendarUtil.create(2019, 6, 30); // Sunday
-    final LocalDate expectedDate = calendarUtil.create(2019, 7, 1); // Monday
+    final LocalDate date = CalendarUtil.create(2019, 6, 30); // Sunday
+    final LocalDate expectedDate = CalendarUtil.create(2019, 7, 1); // Monday
     assertEquals(expectedDate, date.with(adjuster));
   }
 
   @Test
   void testClosestAdjusterNextYear() {
     final TemporalAdjuster adjuster = FixedWeekdayRelativeToFixedParser.closest(DayOfWeek.WEDNESDAY);
-    final LocalDate date = calendarUtil.create(2019, 12, 31); // Tuesday
-    final LocalDate expectedDate = calendarUtil.create(2020, 1, 1); // Wednesday
+    final LocalDate date = CalendarUtil.create(2019, 12, 31); // Tuesday
+    final LocalDate expectedDate = CalendarUtil.create(2020, 1, 1); // Wednesday
     assertEquals(expectedDate, date.with(adjuster));
   }*/
 }

--- a/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/RelativeToEasterSundayParserTest.java
+++ b/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/RelativeToEasterSundayParserTest.java
@@ -14,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RelativeToEasterSundayParserTest {
 
   private final RelativeToEasterSundayParser sut = new RelativeToEasterSundayParser();
-  // private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testForEasterMonday() {
@@ -35,7 +34,7 @@ class RelativeToEasterSundayParserTest {
 
 /* TODO
     final Holiday holiday = holidays.iterator().next();
-    final LocalDate targetDate = calendarUtil.getEasterSunday(year).plusDays(days);
+    final LocalDate targetDate = CalendarUtil.getEasterSunday(year).plusDays(days);
     assertEquals(targetDate, holiday.getDate(), "Wrong date found.");*/
   }
 

--- a/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/RelativeToFixedParserTest.java
+++ b/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/RelativeToFixedParserTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RelativeToFixedParserTest {
 
   private final RelativeToFixedParser sut = new RelativeToFixedParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testEmpty() {
@@ -53,7 +52,7 @@ class RelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 8, 11));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 8, 11));
   }
 
   @Test
@@ -72,7 +71,7 @@ class RelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2016, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2016, 11, 16));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2016, 11, 16));
   }
 
   @Test
@@ -91,6 +90,6 @@ class RelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 8, 2));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 8, 2));
   }
 }

--- a/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/RelativeToWeekdayInMonthParserTest.java
+++ b/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/test/RelativeToWeekdayInMonthParserTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RelativeToWeekdayInMonthParserTest {
 
   private final RelativeToWeekdayInMonthParser sut = new RelativeToWeekdayInMonthParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testEmpty() {
@@ -69,7 +68,7 @@ class RelativeToWeekdayInMonthParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 7, 12));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 7, 12));
   }
 
   @Test
@@ -89,6 +88,6 @@ class RelativeToWeekdayInMonthParserTest {
 
     final List<Holiday> holidays = sut.parse(2018, new JacksonHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2018, 10, 29));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2018, 10, 29));
   }
 }

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/XMLUtil.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/XMLUtil.java
@@ -26,7 +26,6 @@ public class XMLUtil {
   private static final Logger LOG = LoggerFactory.getLogger(XMLUtil.class);
 
   private JAXBContextCreator contextCreator = new JAXBContextCreator();
-  private final ClassLoadingUtil classLoadingUtil = new ClassLoadingUtil();
 
   /**
    * Unmarshalls the configuration from the stream. Uses <code>JAXB</code> for
@@ -42,7 +41,7 @@ public class XMLUtil {
     try {
       JAXBContext ctx;
       try {
-        ctx = contextCreator.create(XMLUtil.PACKAGE, classLoadingUtil.getClassloader());
+        ctx = contextCreator.create(XMLUtil.PACKAGE, ClassLoadingUtil.getClassloader());
       } catch (JAXBException e) {
         LOG.warn("Could not create JAXB context using the current threads context classloader. Falling back to ObjectFactory class classloader.");
         ctx = null;

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/ChristianHolidayParserTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/ChristianHolidayParserTest.java
@@ -29,8 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ChristianHolidayParserTest {
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
-
   private ChristianHolidayParser sut;
 
   @BeforeEach
@@ -51,7 +49,7 @@ class ChristianHolidayParserTest {
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
     final Holiday easterDate = holidays.iterator().next();
-    final LocalDate ed = calendarUtil.create(2011, 4, 24);
+    final LocalDate ed = CalendarUtil.create(2011, 4, 24);
     assertThat(easterDate.getDate()).isEqualTo(ed);
   }
 
@@ -69,7 +67,7 @@ class ChristianHolidayParserTest {
     final RelativeToEasterSundayParser p = new RelativeToEasterSundayParser();
     final List<Holiday> holidays = p.parse(2011, new JaxbHolidays(config));
     final List<LocalDate> expected = new ArrayList<>();
-    expected.add(calendarUtil.create(2011, 4, 25));
+    expected.add(CalendarUtil.create(2011, 4, 25));
     assertThat(holidays).hasSameSizeAs(expected);
     assertThat(holidays.iterator().next().getDate()).isEqualTo(expected.get(0));
   }
@@ -80,13 +78,13 @@ class ChristianHolidayParserTest {
       GENERAL_PRAYER_DAY, PENTECOST, SACRED_HEART);
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
     final List<LocalDate> expected = new ArrayList<>();
-    expected.add(calendarUtil.create(2011, 3, 7));
-    expected.add(calendarUtil.create(2011, 4, 23));
-    expected.add(calendarUtil.create(2011, 4, 24));
-    expected.add(calendarUtil.create(2011, 4, 26));
-    expected.add(calendarUtil.create(2011, 5, 20));
-    expected.add(calendarUtil.create(2011, 6, 12));
-    expected.add(calendarUtil.create(2011, 7, 1));
+    expected.add(CalendarUtil.create(2011, 3, 7));
+    expected.add(CalendarUtil.create(2011, 4, 23));
+    expected.add(CalendarUtil.create(2011, 4, 24));
+    expected.add(CalendarUtil.create(2011, 4, 26));
+    expected.add(CalendarUtil.create(2011, 5, 20));
+    expected.add(CalendarUtil.create(2011, 6, 12));
+    expected.add(CalendarUtil.create(2011, 7, 1));
 
     assertThat(holidays).hasSameSizeAs(expected);
 
@@ -106,7 +104,7 @@ class ChristianHolidayParserTest {
     final List<Holiday> holidays = sut.parse(2019, new JaxbHolidays(config));
 
     final String expectedPropertiesKey = "CUSTOM_KEY";
-    final LocalDate expectedDate = calendarUtil.create(2019, 4, 23);
+    final LocalDate expectedDate = CalendarUtil.create(2019, 4, 23);
 
     assertThat(holidays).hasSize(1);
 

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/EthiopianOrthodoxHolidayParserTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/EthiopianOrthodoxHolidayParserTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EthiopianOrthodoxHolidayParserTest {
 
   private final EthiopianOrthodoxHolidayParser sut = new EthiopianOrthodoxHolidayParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testEmpty() {
@@ -41,13 +40,13 @@ class EthiopianOrthodoxHolidayParserTest {
 
     final List<Holiday> holidays = sut.parse(2010, new JaxbHolidays(config));
     assertThat(holidays).hasSize(3);
-    assertContains(calendarUtil.create(2010, 1, 18), Sets.newHashSet(holidays));
-    assertContains(calendarUtil.create(2010, 9, 11), Sets.newHashSet(holidays));
-    assertContains(calendarUtil.create(2010, 9, 27), Sets.newHashSet(holidays));
+    assertContains(CalendarUtil.create(2010, 1, 18), Sets.newHashSet(holidays));
+    assertContains(CalendarUtil.create(2010, 9, 11), Sets.newHashSet(holidays));
+    assertContains(CalendarUtil.create(2010, 9, 27), Sets.newHashSet(holidays));
   }
 
   private void assertContains(LocalDate date, Set<Holiday> holidays) {
-    assertThat(calendarUtil.contains(holidays, date)).isTrue();
+    assertThat(CalendarUtil.contains(holidays, date)).isTrue();
   }
 
   private EthiopianOrthodoxHoliday createHoliday(EthiopianOrthodoxHolidayType type) {

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/FixedParserTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/FixedParserTest.java
@@ -34,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FixedParserTest {
 
   private final FixedParser sut = new FixedParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testFixedWithValidity() {
@@ -45,7 +44,7 @@ class FixedParserTest {
     );
 
     final List<Holiday> holidays = sut.parse(2010, new JaxbHolidays(config));
-    containsAll(holidays, calendarUtil.create(2010, 1, 1), calendarUtil.create(2010, 3, 3));
+    containsAll(holidays, CalendarUtil.create(2010, 1, 1), CalendarUtil.create(2010, 3, 3));
   }
 
   @Test
@@ -56,7 +55,7 @@ class FixedParserTest {
     );
 
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
-    containsAll(holidays, calendarUtil.create(2011, 1, 7), calendarUtil.create(2011, 1, 24));
+    containsAll(holidays, CalendarUtil.create(2011, 1, 7), CalendarUtil.create(2011, 1, 24));
   }
 
   @Test

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/FixedWeekdayBetweenFixedParserTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/FixedWeekdayBetweenFixedParserTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FixedWeekdayBetweenFixedParserTest extends FixedParserTest {
 
   private final FixedWeekdayBetweenFixedParser sut = new FixedWeekdayBetweenFixedParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testEmpty() {
@@ -51,6 +50,6 @@ class FixedWeekdayBetweenFixedParserTest extends FixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 1, 19));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 1, 19));
   }
 }

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/FixedWeekdayRelativeToFixedParserTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/FixedWeekdayRelativeToFixedParserTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FixedWeekdayRelativeToFixedParserTest {
 
   private final FixedWeekdayRelativeToFixedParser sut = new FixedWeekdayRelativeToFixedParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testEmpty() {
@@ -65,7 +64,7 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 1, 24));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 1, 24));
   }
 
   @Test
@@ -84,7 +83,7 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 1, 17));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 1, 17));
   }
 
   @Test
@@ -104,7 +103,7 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 2, 14));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 2, 14));
   }
 
   @Test
@@ -124,7 +123,7 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 4, 12));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 4, 12));
   }
 
   @Test
@@ -144,7 +143,7 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2019, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2019, 6, 11));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2019, 6, 11));
   }
 
   @Test
@@ -165,39 +164,39 @@ class FixedWeekdayRelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2019, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2019, 6, 11));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2019, 6, 11));
   }
 
 /* TODO
   @Test
   void testClosestAdjusterSameMonth() {
     final TemporalAdjuster adjuster = FixedWeekdayRelativeToFixedParser.closest(DayOfWeek.MONDAY);
-    final LocalDate date = calendarUtil.create(2018, 12, 1); // Saturday
-    final LocalDate expectedDate = calendarUtil.create(2018, 12, 3); // Monday
+    final LocalDate date = CalendarUtil.create(2018, 12, 1); // Saturday
+    final LocalDate expectedDate = CalendarUtil.create(2018, 12, 3); // Monday
     assertEquals(expectedDate, date.with(adjuster));
   }
 
   @Test
   void testClosestAdjusterPreviousMonth() {
     final TemporalAdjuster adjuster = FixedWeekdayRelativeToFixedParser.closest(DayOfWeek.FRIDAY);
-    final LocalDate date = calendarUtil.create(2019, 6, 3); // Monday
-    final LocalDate expectedDate = calendarUtil.create(2019, 5, 31); // Friday
+    final LocalDate date = CalendarUtil.create(2019, 6, 3); // Monday
+    final LocalDate expectedDate = CalendarUtil.create(2019, 5, 31); // Friday
     assertEquals(expectedDate, date.with(adjuster));
   }
 
   @Test
   void testClosestAdjusterNextMonth() {
     final TemporalAdjuster adjuster = FixedWeekdayRelativeToFixedParser.closest(DayOfWeek.MONDAY);
-    final LocalDate date = calendarUtil.create(2019, 6, 30); // Sunday
-    final LocalDate expectedDate = calendarUtil.create(2019, 7, 1); // Monday
+    final LocalDate date = CalendarUtil.create(2019, 6, 30); // Sunday
+    final LocalDate expectedDate = CalendarUtil.create(2019, 7, 1); // Monday
     assertEquals(expectedDate, date.with(adjuster));
   }
 
   @Test
   void testClosestAdjusterNextYear() {
     final TemporalAdjuster adjuster = FixedWeekdayRelativeToFixedParser.closest(DayOfWeek.WEDNESDAY);
-    final LocalDate date = calendarUtil.create(2019, 12, 31); // Tuesday
-    final LocalDate expectedDate = calendarUtil.create(2020, 1, 1); // Wednesday
+    final LocalDate date = CalendarUtil.create(2019, 12, 31); // Tuesday
+    final LocalDate expectedDate = CalendarUtil.create(2020, 1, 1); // Wednesday
     assertEquals(expectedDate, date.with(adjuster));
   }*/
 }

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/RelativeToEasterSundayParserTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/RelativeToEasterSundayParserTest.java
@@ -14,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RelativeToEasterSundayParserTest {
 
   private final RelativeToEasterSundayParser sut = new RelativeToEasterSundayParser();
-  // private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testForEasterMonday() {
@@ -35,7 +34,7 @@ class RelativeToEasterSundayParserTest {
 
 /* TODO
     final Holiday holiday = holidays.iterator().next();
-    final LocalDate targetDate = calendarUtil.getEasterSunday(year).plusDays(days);
+    final LocalDate targetDate = CalendarUtil.getEasterSunday(year).plusDays(days);
     assertEquals(targetDate, holiday.getDate(), "Wrong date found.");*/
   }
 

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/RelativeToFixedParserTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/RelativeToFixedParserTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RelativeToFixedParserTest {
 
   private final RelativeToFixedParser sut = new RelativeToFixedParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testEmpty() {
@@ -53,7 +52,7 @@ class RelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 8, 11));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 8, 11));
   }
 
   @Test
@@ -72,7 +71,7 @@ class RelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2016, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2016, 11, 16));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2016, 11, 16));
   }
 
   @Test
@@ -91,6 +90,6 @@ class RelativeToFixedParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 8, 2));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 8, 2));
   }
 }

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/RelativeToWeekdayInMonthParserTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/test/RelativeToWeekdayInMonthParserTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RelativeToWeekdayInMonthParserTest {
 
   private final RelativeToWeekdayInMonthParser sut = new RelativeToWeekdayInMonthParser();
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testEmpty() {
@@ -69,7 +68,7 @@ class RelativeToWeekdayInMonthParserTest {
 
     final List<Holiday> holidays = sut.parse(2011, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2011, 7, 12));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2011, 7, 12));
   }
 
   @Test
@@ -89,6 +88,6 @@ class RelativeToWeekdayInMonthParserTest {
 
     final List<Holiday> holidays = sut.parse(2018, new JaxbHolidays(config));
     assertThat(holidays).hasSize(1);
-    assertThat(holidays.iterator().next().getDate()).isEqualTo(calendarUtil.create(2018, 10, 29));
+    assertThat(holidays.iterator().next().getDate()).isEqualTo(CalendarUtil.create(2018, 10, 29));
   }
 }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/HolidayManagerTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/HolidayManagerTest.java
@@ -47,8 +47,6 @@ class HolidayManagerTest {
   private static final Set<LocalDate> test_days_l2 = new HashSet<>();
   private static final Set<LocalDate> test_days_l11 = new HashSet<>();
 
-  private final static CalendarUtil calendarUtil = new CalendarUtil();
-
   static {
     test_days.add(LocalDate.of(2010, FEBRUARY, 17));
     test_days.add(LocalDate.of(2010, AUGUST, 30));
@@ -174,7 +172,7 @@ class HolidayManagerTest {
 
   private void assertDates(Set<LocalDate> expected, Set<Holiday> holidays) {
     for (LocalDate localDate : expected) {
-      if (!calendarUtil.contains(holidays, localDate)) {
+      if (!CalendarUtil.contains(holidays, localDate)) {
         fail("Missing " + localDate + " in " + holidays);
       }
     }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/AbstractCountryTestBase.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/AbstractCountryTestBase.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractCountryTestBase {
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   protected void validateCalendarData(final String countryCode, int year) {
     validateCalendarData(countryCode, year, false);
@@ -104,7 +103,7 @@ public abstract class AbstractCountryTestBase {
 
     for (final Holiday expectedHoliday : expectedHolidays) {
       assertThat(expectedHoliday.getDescription()).isNotNull();
-      if (!calendarUtil.contains(foundHolidays, expectedHoliday.getDate())) {
+      if (!CalendarUtil.contains(foundHolidays, expectedHoliday.getDate())) {
         fail("Could not find " + expectedHoliday + " in " + expectedHierarchy.getDescription() + " - " + foundHolidays);
       }
     }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayAETest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayAETest.java
@@ -17,7 +17,6 @@ class HolidayAETest extends AbstractCountryTestBase {
 
   private static final int YEAR = 2019;
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testNumberOfHolidays() {
@@ -28,7 +27,7 @@ class HolidayAETest extends AbstractCountryTestBase {
 
   @Test
   void testRamadanEnd() {
-    final LocalDate expected = calendarUtil.create(YEAR, 6, 3);
+    final LocalDate expected = CalendarUtil.create(YEAR, 6, 3);
     final HolidayManager holidayManager = HolidayManager.getInstance(ManagerParameters.create(UNITED_ARAB_EMIRATES));
     final Set<Holiday> holidays = holidayManager.getHolidays(YEAR);
     assertThat(holidays).hasSize(13);

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayBMTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayBMTest.java
@@ -20,7 +20,6 @@ class HolidayBMTest extends AbstractCountryTestBase {
 
   private static final String ISO_CODE = "bm";
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @ParameterizedTest
   @ValueSource(ints = {2015, 2016, 2017, 2018, 2020, 2021, 2022, 2023, 2024, 2025})
@@ -32,15 +31,15 @@ class HolidayBMTest extends AbstractCountryTestBase {
   void testManagerBMInterval() {
     try {
       final HolidayManager instance = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.BERMUDA, null));
-      final LocalDate startDateInclusive = calendarUtil.create(2022, 10, 1);
-      final LocalDate endDateInclusive = calendarUtil.create(2023, 1, 31);
+      final LocalDate startDateInclusive = CalendarUtil.create(2022, 10, 1);
+      final LocalDate endDateInclusive = CalendarUtil.create(2023, 1, 31);
       final Set<Holiday> holidays = instance.getHolidays(startDateInclusive, endDateInclusive);
-      final List<LocalDate> expected = List.of(calendarUtil.create(2022, 11, 11),
-        calendarUtil.create(2022, 12, 26), calendarUtil.create(2022, 12, 27),
-        calendarUtil.create(2023, 1, 2));
+      final List<LocalDate> expected = List.of(CalendarUtil.create(2022, 11, 11),
+        CalendarUtil.create(2022, 12, 26), CalendarUtil.create(2022, 12, 27),
+        CalendarUtil.create(2023, 1, 2));
       assertThat(holidays).hasSameSizeAs(expected);
       for (LocalDate d : expected) {
-        assertThat(calendarUtil.contains(holidays, d)).isTrue();
+        assertThat(CalendarUtil.contains(holidays, d)).isTrue();
       }
     } catch (Exception e) {
       fail("Unexpected error occurred: " + e.getClass().getName() + " - " + e.getMessage());

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayDETest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayDETest.java
@@ -25,8 +25,6 @@ class HolidayDETest extends AbstractCountryTestBase {
 
   private static final String ISO_CODE = "de";
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
-
 
   @ParameterizedTest
   @ValueSource(ints = {2010, 2022, 2023})
@@ -38,15 +36,15 @@ class HolidayDETest extends AbstractCountryTestBase {
   void testManagerDEInterval() {
     try {
       final HolidayManager instance = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.GERMANY, null));
-      final LocalDate startDateInclusive = calendarUtil.create(2010, 10, 1);
-      final LocalDate endDateInclusive = calendarUtil.create(2011, 1, 31);
+      final LocalDate startDateInclusive = CalendarUtil.create(2010, 10, 1);
+      final LocalDate endDateInclusive = CalendarUtil.create(2011, 1, 31);
       final Set<Holiday> holidays = instance.getHolidays(startDateInclusive, endDateInclusive);
-      final List<LocalDate> expected = List.of(calendarUtil.create(2010, 12, 25),
-        calendarUtil.create(2010, 12, 26), calendarUtil.create(2010, 10, 3),
-        calendarUtil.create(2011, 1, 1));
+      final List<LocalDate> expected = List.of(CalendarUtil.create(2010, 12, 25),
+        CalendarUtil.create(2010, 12, 26), CalendarUtil.create(2010, 10, 3),
+        CalendarUtil.create(2011, 1, 1));
       assertThat(holidays).hasSameSizeAs(expected);
       for (LocalDate d : expected) {
-        assertThat(calendarUtil.contains(holidays, d)).isTrue();
+        assertThat(CalendarUtil.contains(holidays, d)).isTrue();
       }
     } catch (Exception e) {
       fail("Unexpected error occurred: " + e.getClass().getName() + " - " + e.getMessage());

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayEGTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayEGTest.java
@@ -15,7 +15,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HolidayEGTest extends AbstractCountryTestBase {
 
   private static final int YEAR = 2019;
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testNumberOfHolidays() {
@@ -26,7 +25,7 @@ class HolidayEGTest extends AbstractCountryTestBase {
 
   @Test
   void testEasterMonday2019() {
-    final LocalDate expected = calendarUtil.create(YEAR, 4, 29);
+    final LocalDate expected = CalendarUtil.create(YEAR, 4, 29);
     final HolidayManager holidayManager = HolidayManager.getInstance(ManagerParameters.create(EGYPT));
     final Set<Holiday> holidays = holidayManager.getHolidays(YEAR);
     assertThat(holidays).hasSize(17);
@@ -36,7 +35,7 @@ class HolidayEGTest extends AbstractCountryTestBase {
 
   @Test
   void testEidFitr2019() {
-    final LocalDate expected = calendarUtil.create(YEAR, 6, 4);
+    final LocalDate expected = CalendarUtil.create(YEAR, 6, 4);
     final HolidayManager holidayManager = HolidayManager.getInstance(ManagerParameters.create(EGYPT));
     final Set<Holiday> holidays = holidayManager.getHolidays(YEAR);
     assertThat(holidays).hasSize(17);
@@ -46,7 +45,7 @@ class HolidayEGTest extends AbstractCountryTestBase {
 
   @Test
   void testArafaat2019() {
-    final LocalDate expected = calendarUtil.create(YEAR, 8, 10);
+    final LocalDate expected = CalendarUtil.create(YEAR, 8, 10);
     final HolidayManager holidayManager = HolidayManager.getInstance(ManagerParameters.create(EGYPT));
     final Set<Holiday> holidays = holidayManager.getHolidays(YEAR);
     assertThat(holidays).hasSize(17);

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayHKTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayHKTest.java
@@ -20,7 +20,6 @@ class HolidayHKTest extends AbstractCountryTestBase {
 
   private static final String ISO_CODE = "hk";
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @ParameterizedTest
   @ValueSource(ints = {2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024})
@@ -32,17 +31,17 @@ class HolidayHKTest extends AbstractCountryTestBase {
   void testManagerHKInterval() {
     try {
       final HolidayManager instance = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.HONG_KONG, null));
-      final LocalDate startDateInclusive = calendarUtil.create(2022, 10, 1);
-      final LocalDate endDateInclusive = calendarUtil.create(2023, 1, 31);
+      final LocalDate startDateInclusive = CalendarUtil.create(2022, 10, 1);
+      final LocalDate endDateInclusive = CalendarUtil.create(2023, 1, 31);
       final Set<Holiday> holidays = instance.getHolidays(startDateInclusive, endDateInclusive);
-      final List<LocalDate> expected = List.of(calendarUtil.create(2022, 10, 1),
-        calendarUtil.create(2022, 10, 4), calendarUtil.create(2022, 12, 26),
-        calendarUtil.create(2022, 12, 27), calendarUtil.create(2023, 1, 2),
-        calendarUtil.create(2023, 1, 23), calendarUtil.create(2023, 1, 24),
-        calendarUtil.create(2023, 1, 25));
+      final List<LocalDate> expected = List.of(CalendarUtil.create(2022, 10, 1),
+        CalendarUtil.create(2022, 10, 4), CalendarUtil.create(2022, 12, 26),
+        CalendarUtil.create(2022, 12, 27), CalendarUtil.create(2023, 1, 2),
+        CalendarUtil.create(2023, 1, 23), CalendarUtil.create(2023, 1, 24),
+        CalendarUtil.create(2023, 1, 25));
       assertThat(holidays).hasSameSizeAs(expected);
       for (LocalDate d : expected) {
-        assertThat(calendarUtil.contains(holidays, d)).isTrue();
+        assertThat(CalendarUtil.contains(holidays, d)).isTrue();
       }
     } catch (Exception e) {
       fail("Unexpected error occurred: " + e.getClass().getName() + " - " + e.getMessage());

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayKYTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayKYTest.java
@@ -20,7 +20,6 @@ class HolidayKYTest extends AbstractCountryTestBase {
 
   private static final String ISO_CODE = "ky";
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @ParameterizedTest
   @ValueSource(ints = {2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023})
@@ -32,15 +31,15 @@ class HolidayKYTest extends AbstractCountryTestBase {
   void testManagerKYInterval() {
     try {
       final HolidayManager instance = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.CAYMAN_ISLANDS, null));
-      final LocalDate startDateInclusive = calendarUtil.create(2022, 10, 1);
-      final LocalDate endDateInclusive = calendarUtil.create(2023, 1, 31);
+      final LocalDate startDateInclusive = CalendarUtil.create(2022, 10, 1);
+      final LocalDate endDateInclusive = CalendarUtil.create(2023, 1, 31);
       final Set<Holiday> holidays = instance.getHolidays(startDateInclusive, endDateInclusive);
-      final List<LocalDate> expected = List.of(calendarUtil.create(2022, 11, 14),
-        calendarUtil.create(2022, 12, 26), calendarUtil.create(2022, 12, 27),
-        calendarUtil.create(2023, 1, 2), calendarUtil.create(2023, 1, 23));
+      final List<LocalDate> expected = List.of(CalendarUtil.create(2022, 11, 14),
+        CalendarUtil.create(2022, 12, 26), CalendarUtil.create(2022, 12, 27),
+        CalendarUtil.create(2023, 1, 2), CalendarUtil.create(2023, 1, 23));
       assertThat(holidays).hasSameSizeAs(expected);
       for (LocalDate d : expected) {
-        assertThat(calendarUtil.contains(holidays, d)).isTrue();
+        assertThat(CalendarUtil.contains(holidays, d)).isTrue();
       }
     } catch (Exception e) {
       fail("Unexpected error occurred: " + e.getClass().getName() + " - " + e.getMessage());

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayMUTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayMUTest.java
@@ -20,7 +20,6 @@ class HolidayMUTest extends AbstractCountryTestBase {
 
   private static final String ISO_CODE = "mu";
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @ParameterizedTest
   @ValueSource(ints = {2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024})
@@ -32,16 +31,16 @@ class HolidayMUTest extends AbstractCountryTestBase {
   void testManagerMUInterval() {
     try {
       final HolidayManager instance = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.MAURITIUS, null));
-      final LocalDate startDateInclusive = calendarUtil.create(2022, 10, 1);
-      final LocalDate endDateInclusive = calendarUtil.create(2023, 1, 31);
+      final LocalDate startDateInclusive = CalendarUtil.create(2022, 10, 1);
+      final LocalDate endDateInclusive = CalendarUtil.create(2023, 1, 31);
       final Set<Holiday> holidays = instance.getHolidays(startDateInclusive, endDateInclusive);
-      final List<LocalDate> expected = List.of(calendarUtil.create(2022, 10, 24),
-        calendarUtil.create(2022, 11, 2), calendarUtil.create(2022, 12, 25),
-        calendarUtil.create(2023, 1, 1), calendarUtil.create(2023, 1, 2),
-        calendarUtil.create(2023, 1, 3), calendarUtil.create(2023, 1, 22));
+      final List<LocalDate> expected = List.of(CalendarUtil.create(2022, 10, 24),
+        CalendarUtil.create(2022, 11, 2), CalendarUtil.create(2022, 12, 25),
+        CalendarUtil.create(2023, 1, 1), CalendarUtil.create(2023, 1, 2),
+        CalendarUtil.create(2023, 1, 3), CalendarUtil.create(2023, 1, 22));
       assertThat(holidays).hasSameSizeAs(expected);
       for (LocalDate d : expected) {
-        assertThat(calendarUtil.contains(holidays, d)).isTrue();
+        assertThat(CalendarUtil.contains(holidays, d)).isTrue();
       }
     } catch (Exception e) {
       fail("Unexpected error occurred: " + e.getClass().getName() + " - " + e.getMessage());

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayNZTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayNZTest.java
@@ -23,7 +23,6 @@ class HolidayNZTest extends AbstractCountryTestBase {
   private static final String ISO_CODE = "nz";
   private static final int YEAR = 2018;
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
   private final HolidayManager holidayManager = HolidayManager.getInstance(create(NEW_ZEALAND));
 
   @Test
@@ -34,7 +33,7 @@ class HolidayNZTest extends AbstractCountryTestBase {
   @Test
   void testSouthlandAnniversary2011() {
     // Monday closest to 17 January
-    final LocalDate expected = calendarUtil.create(2011, 1, 17);
+    final LocalDate expected = CalendarUtil.create(2011, 1, 17);
     final Set<Holiday> holidays = holidayManager.getHolidays(2011, "stl");
 
     boolean found = holidays.stream()
@@ -45,7 +44,7 @@ class HolidayNZTest extends AbstractCountryTestBase {
   @Test
   void testSouthlandAnniversary2012() {
     // Easter Tuesday
-    final LocalDate expected = calendarUtil.create(2012, 4, 10);
+    final LocalDate expected = CalendarUtil.create(2012, 4, 10);
     final Set<Holiday> holidays = holidayManager.getHolidays(2012, "stl");
 
     boolean found = holidays.stream()

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidaySGTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidaySGTest.java
@@ -20,7 +20,6 @@ class HolidaySGTest extends AbstractCountryTestBase {
 
   private static final String ISO_CODE = "sg";
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @ParameterizedTest
   @ValueSource(ints = {2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024})
@@ -32,15 +31,15 @@ class HolidaySGTest extends AbstractCountryTestBase {
   void testManagerSGInterval() {
     try {
       final HolidayManager instance = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.SINGAPORE, null));
-      final LocalDate startDateInclusive = calendarUtil.create(2022, 10, 1);
-      final LocalDate endDateInclusive = calendarUtil.create(2023, 1, 31);
+      final LocalDate startDateInclusive = CalendarUtil.create(2022, 10, 1);
+      final LocalDate endDateInclusive = CalendarUtil.create(2023, 1, 31);
       final Set<Holiday> holidays = instance.getHolidays(startDateInclusive, endDateInclusive);
-      final List<LocalDate> expected = List.of(calendarUtil.create(2022, 10, 24),
-        calendarUtil.create(2022, 12, 26), calendarUtil.create(2023, 1, 2),
-        calendarUtil.create(2023, 1, 24), calendarUtil.create(2023, 1, 23));
+      final List<LocalDate> expected = List.of(CalendarUtil.create(2022, 10, 24),
+        CalendarUtil.create(2022, 12, 26), CalendarUtil.create(2023, 1, 2),
+        CalendarUtil.create(2023, 1, 24), CalendarUtil.create(2023, 1, 23));
       assertThat(holidays).hasSameSizeAs(expected);
       for (LocalDate d : expected) {
-        assertThat(calendarUtil.contains(holidays, d)).isTrue();
+        assertThat(CalendarUtil.contains(holidays, d)).isTrue();
       }
     } catch (Exception e) {
       fail("Unexpected error occurred: " + e.getClass().getName() + " - " + e.getMessage());

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayTRTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayTRTest.java
@@ -17,7 +17,6 @@ class HolidayTRTest extends AbstractCountryTestBase {
   private static final String ISO_CODE = "tr";
   private static final int YEAR = 2019;
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @Test
   void testManagerTRStructure() {
@@ -34,7 +33,7 @@ class HolidayTRTest extends AbstractCountryTestBase {
   @Test
   void testRamazan2019() {
     // Actually, in Turkey, Ramadan is one day after Eid Mubarak, for keep the Eid al Fitr for now
-    final LocalDate expected = calendarUtil.create(YEAR, 6, 4);
+    final LocalDate expected = CalendarUtil.create(YEAR, 6, 4);
     final HolidayManager holidayManager = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.TURKEY));
     final Set<Holiday> holidays = holidayManager.getHolidays(YEAR);
     assertThat(holidays).hasSize(9);
@@ -51,7 +50,7 @@ class HolidayTRTest extends AbstractCountryTestBase {
 
   @Test
   void testKurban2019() {
-    final LocalDate expected = calendarUtil.create(YEAR, 8, 11);
+    final LocalDate expected = CalendarUtil.create(YEAR, 8, 11);
     final HolidayManager holidayManager = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.TURKEY));
     final Set<Holiday> holidays = holidayManager.getHolidays(YEAR);
     assertThat(holidays).hasSize(9);

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayVGTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayVGTest.java
@@ -20,7 +20,6 @@ class HolidayVGTest extends AbstractCountryTestBase {
 
   private static final String ISO_CODE = "vg";
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @ParameterizedTest
   @ValueSource(ints = {2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023})
@@ -32,15 +31,15 @@ class HolidayVGTest extends AbstractCountryTestBase {
   void testManagerVGInterval() {
     try {
       final HolidayManager instance = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.BRITISH_VIRGIN_ISLANDS, null));
-      final LocalDate startDateInclusive = calendarUtil.create(2015, 10, 1);
-      final LocalDate endDateInclusive = calendarUtil.create(2016, 1, 31);
+      final LocalDate startDateInclusive = CalendarUtil.create(2015, 10, 1);
+      final LocalDate endDateInclusive = CalendarUtil.create(2016, 1, 31);
       final Set<Holiday> holidays = instance.getHolidays(startDateInclusive, endDateInclusive);
-      final List<LocalDate> expected = List.of(calendarUtil.create(2015, 12, 25),
-        calendarUtil.create(2015, 12, 28), calendarUtil.create(2015, 10, 19),
-        calendarUtil.create(2016, 1, 1));
+      final List<LocalDate> expected = List.of(CalendarUtil.create(2015, 12, 25),
+        CalendarUtil.create(2015, 12, 28), CalendarUtil.create(2015, 10, 19),
+        CalendarUtil.create(2016, 1, 1));
       assertThat(holidays).hasSameSizeAs(expected);
       for (LocalDate d : expected) {
-        assertThat(calendarUtil.contains(holidays, d)).isTrue();
+        assertThat(CalendarUtil.contains(holidays, d)).isTrue();
       }
     } catch (Exception e) {
       fail("Unexpected error occurred: " + e.getClass().getName() + " - " + e.getMessage());

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayXKTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayXKTest.java
@@ -20,7 +20,6 @@ class HolidayXKTest extends AbstractCountryTestBase {
 
   private static final String ISO_CODE = "xk";
 
-  private final CalendarUtil calendarUtil = new CalendarUtil();
 
   @ParameterizedTest
   @ValueSource(ints = {2021, 2022, 2023})
@@ -31,28 +30,28 @@ class HolidayXKTest extends AbstractCountryTestBase {
   @Test
   void testManagerXKInterval() {
     HolidayManager instance = HolidayManager.getInstance(ManagerParameters.create(KOSOVO));
-    Set<Holiday> holidays = instance.getHolidays(calendarUtil.create(2010, 6, 1),
-      calendarUtil.create(2011, 5, 31));
+    Set<Holiday> holidays = instance.getHolidays(CalendarUtil.create(2010, 6, 1),
+      CalendarUtil.create(2011, 5, 31));
 
-    List<LocalDate> expected = Arrays.asList(calendarUtil.create(2010, 6, 12),
-      calendarUtil.create(2010, 6, 15),
-      calendarUtil.create(2010, 9, 28),
-      calendarUtil.create(2010, 11, 28),
-      calendarUtil.create(2010, 12, 25),
-      calendarUtil.create(2011, 1, 1),
-      calendarUtil.create(2011, 2, 15),
-      calendarUtil.create(2011, 2, 17),
-      calendarUtil.create(2011, 3, 6),
-      calendarUtil.create(2011, 3, 8),
-      calendarUtil.create(2011, 4, 23),
-      calendarUtil.create(2011, 5, 1),
-      calendarUtil.create(2011, 5, 6),
-      calendarUtil.create(2011, 5, 9)
+    List<LocalDate> expected = Arrays.asList(CalendarUtil.create(2010, 6, 12),
+      CalendarUtil.create(2010, 6, 15),
+      CalendarUtil.create(2010, 9, 28),
+      CalendarUtil.create(2010, 11, 28),
+      CalendarUtil.create(2010, 12, 25),
+      CalendarUtil.create(2011, 1, 1),
+      CalendarUtil.create(2011, 2, 15),
+      CalendarUtil.create(2011, 2, 17),
+      CalendarUtil.create(2011, 3, 6),
+      CalendarUtil.create(2011, 3, 8),
+      CalendarUtil.create(2011, 4, 23),
+      CalendarUtil.create(2011, 5, 1),
+      CalendarUtil.create(2011, 5, 6),
+      CalendarUtil.create(2011, 5, 9)
     );
 
     assertThat(holidays).hasSameSizeAs(expected);
     holidays.forEach(holiday -> assertThat(expected).contains(holiday.getDate()));
-    expected.forEach(d -> assertThat(calendarUtil.contains(holidays, d)).isTrue());
+    expected.forEach(d -> assertThat(CalendarUtil.contains(holidays, d)).isTrue());
   }
 
   @Test


### PR DESCRIPTION
All the method in the util classes are independent from the class, with a little exception of ResourceUtil#getResource. There is not need to create a class of the utils to access static code. So in this PR increases the static access to the util classes in the first place.