### PR TITLE
Check holidays 02/2024

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_bm.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_bm.xml
@@ -91,4 +91,11 @@
       <to month="AUGUST" day="4"/>
     </FixedWeekdayBetweenFixed>
   </Holidays>
+
+  <Sources>
+    <Source>https://www.gov.bm/public-holidays</Source>
+    <Source>https://en.wikipedia.org/wiki/Public_holidays_in_Bermuda</Source>
+    <Source of="ISO 3166">https://www.iso.org/obp/ui/#iso:code:3166:BM</Source>
+    <Source of="ISO 3166-2">https://en.wikipedia.org/wiki/ISO_3166-2:BM</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_hk.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_hk.xml
@@ -4,8 +4,6 @@
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
   <Holidays>
-    <!-- https://www.gov.hk/en/about/abouthk/holiday/index.htm -->
-    <!-- https://www.elegislation.gov.hk/hk/cap149!en-zh-Hant-HK.pdf -->
     <!-- all holidays in Hong Kong will be moved to the following weekday, that isn't a holiday, if they fall on a Sunday
     or such other day as the Chief Executive in Council may, by order in the Gazette, appoint in place of that day -->
 
@@ -633,4 +631,12 @@
     <ChristianHoliday type="EASTER_TUESDAY" validFrom="2021" validTo="2021" descriptionPropertiesKey="DAY_FOLLOWING_EASTER_MONDAY"/>
     <ChristianHoliday type="EASTER_MONDAY" validFrom="2022" descriptionPropertiesKey="christian.EASTER_MONDAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://www.gov.hk/en/about/abouthk/holiday/</Source>
+    <Source>https://www.elegislation.gov.hk/hk/cap149!en-zh-Hant-HK.pdf</Source>
+    <Source>https://en.wikipedia.org/wiki/Public_holidays_in_Hong_Kong</Source>
+    <Source of="ISO 3166">https://www.iso.org/obp/ui/#iso:code:3166:HK</Source>
+    <Source of="ISO 3166-2">https://en.wikipedia.org/wiki/ISO_3166-2:HK</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_ky.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_ky.xml
@@ -20,9 +20,6 @@
     <!-- https://www.gov.ky/news/press-release-details/public-holidays-2022 -->
     <Fixed month="JUNE" day="3" validFrom="2022" validTo="2022" descriptionPropertiesKey="QUEENS_PLATINUM_JUBILEE"/>
 
-    <!-- https://www.gov.ky/calendar/public-holidays -->
-    <Fixed month="JUNE" day="19" validFrom="2023" descriptionPropertiesKey="KINGS_DAY"/>
-
     <!-- https://archives.gov.ky/Archive/view_press_release/3325/yes-its-a-public-holiday -->
     <Fixed month="NOVEMBER" day="6" validFrom="2009" validTo="2009" descriptionPropertiesKey="CONSTITUTION_COMMENCEMENT_2009"/>
 
@@ -41,7 +38,8 @@
     <!-- parliament dissolved early, assume this will be the new rule, TBD at last in 2025 -->
     <FixedWeekday which="SECOND" weekday="WEDNESDAY" month="APRIL" validFrom="2021" every="FOUR_YEARS" descriptionPropertiesKey="ELECTION_DAY"/>
 
-    <FixedWeekday which="THIRD" weekday="MONDAY" month="MAY" descriptionPropertiesKey="DISCOVERY_DAY"/>
+    <FixedWeekday which="THIRD" weekday="MONDAY" month="MAY" validTo="2023" descriptionPropertiesKey="DISCOVERY_DAY"/>
+    <FixedWeekday which="FIRST" weekday="MONDAY" month="MAY" validFrom="2024" descriptionPropertiesKey="EMANCIPATION_DAY"/>
 
     <FixedWeekday which="FOURTH" weekday="WEDNESDAY" month="MAY" validFrom="2013" validTo="2017" every="FOUR_YEARS"  descriptionPropertiesKey="ELECTION_DAY"/>
 
@@ -57,6 +55,9 @@
     <FixedWeekday which="THIRD" weekday="MONDAY" month="JUNE" validFrom="2020" validTo="2020" descriptionPropertiesKey="QUEENS_BIRTHDAY"/>
     <FixedWeekday which="SECOND" weekday="MONDAY" month="JUNE" validFrom="2021" validTo="2021" descriptionPropertiesKey="QUEENS_BIRTHDAY"/>
     <FixedWeekday which="FIRST" weekday="MONDAY" month="JUNE" validFrom="2022" validTo="2022" descriptionPropertiesKey="QUEENS_BIRTHDAY"/>
+
+    <!-- https://www.gov.ky/calendar/public-holidays -->
+    <FixedWeekday which="THIRD" weekday="MONDAY" month="JUNE" validFrom="2023" descriptionPropertiesKey="KINGS_DAY"/>
 
     <FixedWeekday which="FIRST" weekday="MONDAY" month="JULY" descriptionPropertiesKey="CONSTITUTION_DAY"/>
 
@@ -79,4 +80,11 @@
       <to month="NOVEMBER" day="15"/>
     </FixedWeekdayBetweenFixed>
   </Holidays>
+
+  <Sources>
+    <Source>https://www.gov.ky/calendar/public-holidays</Source>
+    <Source>https://en.wikipedia.org/wiki/Public_holidays_in_the_Cayman_Islands</Source>
+    <Source of="ISO 3166">https://www.iso.org/obp/ui/#iso:code:3166:KY</Source>
+    <Source of="ISO 3166-2">https://en.wikipedia.org/wiki/ISO_3166-2:KY</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_mu.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_mu.xml
@@ -128,4 +128,11 @@
     <IslamicHoliday type="ID_AL_FITR_2" validFrom="2014" every="FOUR_YEARS" descriptionPropertiesKey="islamic.ID_AL_FITR"/>
     <IslamicHoliday type="ID_AL_FITR" validFrom="2016" every="FOUR_YEARS" descriptionPropertiesKey="islamic.ID_AL_FITR"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://attorneygeneral.govmu.org/Documents/Laws%20of%20Mauritius/A-Z%20Acts/P/Pu/PUBLIC%20HOLIDAYS%20ACT,%20No.%2022%20of%201968.pdf</Source>
+    <Source>https://en.wikipedia.org/wiki/Culture_of_Mauritius#Public_holidays_and_festivals</Source>
+    <Source of="ISO 3166">https://www.iso.org/obp/ui/#iso:code:3166:MU</Source>
+    <Source of="ISO 3166-2">https://en.wikipedia.org/wiki/ISO_3166-2:MU</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_sg.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_sg.xml
@@ -239,4 +239,11 @@
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </IslamicHoliday>
   </Holidays>
+
+  <Sources>
+    <Source>https://www.mom.gov.sg/employment-practices/public-holidays</Source>
+    <Source>https://en.wikipedia.org/wiki/Public_holidays_in_Singapore</Source>
+    <Source of="ISO 3166">https://www.iso.org/obp/ui/#iso:code:3166:SG</Source>
+    <Source of="ISO 3166-2">https://en.wikipedia.org/wiki/ISO_3166-2:SG</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_vg.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_vg.xml
@@ -20,15 +20,15 @@
       <MovingCondition substitute="SUNDAY" with="PREVIOUS" weekday="MONDAY"/>
     </Fixed>
 
-    <!-- http://www.bvi.gov.vg/media-centre/bvi-announces-public-holiday-april-21-celebrate-her-majesty-s-birthday -->
-    <!-- http://www.bvi.gov.vg/media-centre/revised-2016-public-holidays -->
+    <!-- https://bvi.gov.vg/media-centre/bvi-announces-public-holiday-april-21-celebrate-her-majesty-s-birthday -->
+    <!-- https://bvi.gov.vg/media-centre/revised-2016-public-holidays -->
     <!-- 2016 it was moved due to the Queen's 90th birthday -->
     <Fixed month="APRIL" day="21" validFrom="2016" validTo="2016" descriptionPropertiesKey="SOVEREIGNS_BIRTHDAY"/>
 
     <!-- https://bvi.gov.vg/media-centre/updatedofficialholidays20231 -->
     <Fixed month="MAY" day="8" validFrom="2023" validTo="2023" descriptionPropertiesKey="KINGS_CORONATION"/>
 
-    <!-- http://www.bvi.gov.vg/media-centre/revised-2022-public-holidays -->
+    <!-- https://bvi.gov.vg/media-centre/revised-2022-public-holidays -->
     <Fixed month="JUNE" day="3" validFrom="2022" validTo="2022" descriptionPropertiesKey="QUEENS_PLATINUM_JUBILEE"/>
     <!-- 2017 it was moved one week later -->
     <Fixed month="JUNE" day="17" validFrom="2017" validTo="2017" descriptionPropertiesKey="SOVEREIGNS_BIRTHDAY"/>
@@ -146,4 +146,11 @@
 
     <ChristianHoliday type="WHIT_MONDAY" descriptionPropertiesKey="christian.WHIT_MONDAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/tags/public-holidays</Source>
+    <Source>https://en.wikipedia.org/wiki/Public_holidays_in_the_British_Virgin_Islands</Source>
+    <Source of="ISO 3166">https://www.iso.org/obp/ui/#iso:code:3166:VG</Source>
+    <Source of="ISO 3166-2">https://en.wikipedia.org/wiki/ISO_3166-2:VG</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayKYTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayKYTest.java
@@ -22,7 +22,7 @@ class HolidayKYTest extends AbstractCountryTestBase {
 
 
   @ParameterizedTest
-  @ValueSource(ints = {2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023})
+  @ValueSource(ints = {2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024})
   void testManagerKYStructure(final int year) {
     validateCalendarData(ISO_CODE, year, true);
   }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayVGTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayVGTest.java
@@ -22,7 +22,7 @@ class HolidayVGTest extends AbstractCountryTestBase {
 
 
   @ParameterizedTest
-  @ValueSource(ints = {2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023})
+  @ValueSource(ints = {2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024})
   void testManagerVGStructure(final int year) {
     validateCalendarData(ISO_CODE, year, true);
   }

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2008.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2008.xml
@@ -16,4 +16,8 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/1503/holidays-for-2008-confirmed</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2009.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2009.xml
@@ -18,4 +18,9 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="28" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/2663/public-holidays-2009</Source>
+    <Source>https://archives.gov.ky/Archive/view_press_release/2356/public-holidays-2009</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2010.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2010.xml
@@ -16,4 +16,8 @@
     <Fixed month="DECEMBER" day="27" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="28" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/3001/2010-public-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2011.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2011.xml
@@ -16,4 +16,9 @@
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="27" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/3836/2011-public-holidays</Source>
+    <Source>https://archives.gov.ky/Archive/view_press_release/3731/announcing-2011-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2014.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2014.xml
@@ -16,4 +16,9 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/4710/public-holidays-2014-confirmed</Source>
+    <Source>https://archives.gov.ky/Archive/view_press_release/4711/public-holidays-for-2014</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2015.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2015.xml
@@ -16,4 +16,8 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="28" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/4916/public-holidays-2015</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2016.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2016.xml
@@ -16,4 +16,9 @@
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="27" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/5215/public-holidays-2016-confirmed</Source>
+    <Source>https://archives.gov.ky/Archive/view_press_release/5147/public-holidays-for-2016</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2017.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2017.xml
@@ -17,4 +17,9 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/5419/2017-public-holidays-updated</Source>
+    <Source>https://archives.gov.ky/Archive/view_press_release/5380/public-holidays-in-2017</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2018.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2018.xml
@@ -16,4 +16,8 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/5612/2018-public-holidays-released</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2019.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2019.xml
@@ -16,4 +16,8 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/5987/2019-public-holidays-listed</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2020.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2020.xml
@@ -16,4 +16,8 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="28" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://archives.gov.ky/Archive/view_press_release/6233/2020-public-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2021.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2021.xml
@@ -17,4 +17,8 @@
     <Fixed month="DECEMBER" day="27" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="28" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://www.gov.ky/news/press-release-details/public-holidays-for-2021</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2024.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_ky_2024.xml
@@ -5,20 +5,20 @@
                xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
   <Holidays>
     <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
-    <Fixed month="JANUARY" day="28" descriptionPropertiesKey="NATIONAL_HEROES_DAY"/>
-    <Fixed month="FEBRUARY" day="13" descriptionPropertiesKey="christian.ASH_WEDNESDAY"/>
+    <Fixed month="JANUARY" day="22" descriptionPropertiesKey="NATIONAL_HEROES_DAY"/>
+    <Fixed month="FEBRUARY" day="14" descriptionPropertiesKey="christian.ASH_WEDNESDAY"/>
     <Fixed month="MARCH" day="29" descriptionPropertiesKey="christian.GOOD_FRIDAY"/>
     <Fixed month="APRIL" day="1" descriptionPropertiesKey="christian.EASTER_MONDAY"/>
-    <Fixed month="MAY" day="20" descriptionPropertiesKey="DISCOVERY_DAY"/>
-    <Fixed month="MAY" day="22" descriptionPropertiesKey="ELECTION_DAY"/>
-    <Fixed month="JUNE" day="17" descriptionPropertiesKey="QUEENS_BIRTHDAY"/>
+    <Fixed month="MAY" day="6" descriptionPropertiesKey="EMANCIPATION_DAY"/>
+    <Fixed month="JUNE" day="17" descriptionPropertiesKey="KINGS_DAY"/>
     <Fixed month="JULY" day="1" descriptionPropertiesKey="CONSTITUTION_DAY"/>
     <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+    <Fixed month="DECEMBER" day="1" descriptionPropertiesKey="CAYMAN_THANKSGIVING"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
 
   <Sources>
-    <Source>https://archives.gov.ky/Archive/view_press_release/4494/public-holidays-in-2013</Source>
+    <Source>https://www.gov.ky/news/press-release-details/2024-public-holidays-named</Source>
   </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2018.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2018.xml
@@ -20,4 +20,8 @@
     <Fixed month="NOVEMBER" day="7" descriptionPropertiesKey="DIVALI"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://pmo.govmu.org/CabinetDecision/2017/Cabinet_Decisions_taken_on_12_MAY_2017.pdf</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2019.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2019.xml
@@ -20,4 +20,8 @@
     <Fixed month="OCTOBER" day="27" descriptionPropertiesKey="DIVALI"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://pmo.govmu.org/CabinetDecision/2018/Cabinet_Decisions_taken_on_25_MAY_2018____.pdf</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2020.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2020.xml
@@ -20,4 +20,11 @@
     <Fixed month="NOVEMBER" day="14" descriptionPropertiesKey="DIVALI"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://pmo.govmu.org/Communique/Public%20holidays%20--%202020.pdf</Source>
+    <Source>https://pmo.govmu.org/CabinetDecision/2019/Cabinet_Decisions_taken_on_07_JUNE_2019.pdf</Source>
+    <Source>https://mauritius-antananarivo.govmu.org/Pages/About%20Us/Public-Holidays-in-Mauritius-for-Year-2020.aspx</Source>
+    <Source>https://mauritius-canberra.govmu.org/Pages/About%20Us/Public-Holidays-in-Australia-for-Year-2020.aspx</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2021.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2021.xml
@@ -20,4 +20,8 @@
     <Fixed month="NOVEMBER" day="4" descriptionPropertiesKey="DIVALI"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://pmo.govmu.org/Communique/Public%20holidays%20-%202021.pdf</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2022.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2022.xml
@@ -20,4 +20,8 @@
     <Fixed month="OCTOBER" day="24" descriptionPropertiesKey="DIVALI"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://pmo.govmu.org/Communique/Public%20holidays%20-%202022.pdf</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2023.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2023.xml
@@ -21,4 +21,9 @@
     <Fixed month="NOVEMBER" day="12" descriptionPropertiesKey="DIVALI"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://pmo.govmu.org/Communique/Public_Holidays_2023.pdf</Source>
+    <Source of="3rd of January">https://pmo.govmu.org/Communique/35_Proclamation%20A5_2022.pdf</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2024.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_mu_2024.xml
@@ -20,4 +20,8 @@
     <Fixed month="OCTOBER" day="31" descriptionPropertiesKey="DIVALI"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://pmo.govmu.org/Communique/Notice%20-%20Final%20Public%20holidays%20-%202024.pdf</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2015.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2015.xml
@@ -19,4 +19,8 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="28" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/media-centre/2015-public-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2016.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2016.xml
@@ -19,4 +19,10 @@
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="27" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/media-centre/bvi-announces-public-holiday-april-21-celebrate-her-majesty-s-birthday</Source>
+    <Source>https://bvi.gov.vg/media-centre/revised-2016-public-holidays</Source>
+    <Source>https://bvi.gov.vg/media-centre/2016-public-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2017.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2017.xml
@@ -19,4 +19,8 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/media-centre/2017-public-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2018.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2018.xml
@@ -19,4 +19,8 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/media-centre/2018-public-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2019.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2019.xml
@@ -19,4 +19,8 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/media-centre/2019-public-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2020.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2020.xml
@@ -19,4 +19,8 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="28" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/media-centre/2020-public-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2021.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2021.xml
@@ -19,4 +19,8 @@
     <Fixed month="DECEMBER" day="27" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="28" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/media-centre/2021-public-holidays-revised</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2022.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2022.xml
@@ -20,4 +20,10 @@
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
     <Fixed month="DECEMBER" day="27" descriptionPropertiesKey="CHRISTMAS"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/media-centre/revised-2022-public-holidays</Source>
+    <Source>https://bvi.org.uk/cabinet-approves-2022-public-holidays/</Source>
+    <Source>https://bvi.gov.vg/media-centre/public-holiday-observe-her-majesty-s-platinum-jubilee</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2023.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2023.xml
@@ -20,4 +20,12 @@
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/media-centre/june-16-public-holiday-lieu-june-9</Source>
+    <Source>https://bvi.gov.vg/media-centre/may-8-and-june-16-declared-public-holidays</Source>
+    <Source>https://bvi.gov.vg/media-centre/monday-may-8-public-holiday</Source>
+    <Source>https://bvi.gov.vg/media-centre/updatedofficialholidays20231</Source>
+    <Source>https://bvi.gov.vg/media-centre/cabinet-approves-2023-public-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2024.xml
+++ b/jollyday-tests/src/test/resources/holidays/Holidays_test_vg_2024.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration hierarchy="vg" description="Virgin Islands (British)"
+               xmlns="https://focus_shift.de/jollyday/schema/holiday"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
+  <Holidays>
+    <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
+    <Fixed month="MARCH" day="4" descriptionPropertiesKey="STOUTTS_BIRTHDAY"/>
+    <Fixed month="MARCH" day="29" descriptionPropertiesKey="christian.GOOD_FRIDAY"/>
+    <Fixed month="APRIL" day="1" descriptionPropertiesKey="christian.EASTER_MONDAY"/>
+    <Fixed month="MAY" day="20" descriptionPropertiesKey="christian.WHIT_MONDAY"/>
+    <Fixed month="JUNE" day="14" descriptionPropertiesKey="SOVEREIGNS_BIRTHDAY"/>
+    <Fixed month="JULY" day="1" descriptionPropertiesKey="VIRGIN_ISLANDS_DAY"/>
+    <Fixed month="AUGUST" day="5" descriptionPropertiesKey="EMANCIPATION_MONDAY"/>
+    <Fixed month="AUGUST" day="6" descriptionPropertiesKey="EMANCIPATION_TUESDAY"/>
+    <Fixed month="AUGUST" day="7" descriptionPropertiesKey="EMANCIPATION_WEDNESDAY"/>
+    <Fixed month="OCTOBER" day="21" descriptionPropertiesKey="HEROES_AND_FOREPARENTS_DAY"/>
+    <Fixed month="NOVEMBER" day="25" descriptionPropertiesKey="1949_GREAT_MARCH_AND_RESTORATION"/>
+    <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+    <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
+  </Holidays>
+
+  <Sources>
+    <Source>https://bvi.gov.vg/media-centre/cabinet-approves-2024-public-holidays</Source>
+  </Sources>
+</Configuration>


### PR DESCRIPTION
 🎁 check that the past holidays (2023 and 2024) and the future holidays (as far as known at the moment) are correct for the countries Hong Kong, Singapore, Mauritius, Bermuda, Cayman Islands and Virgin Islands (British)
 🐞 Discovery Day was replaced by Emancipation Day in the Cayman Islands
 🐞 An unconfirmed date for King's Birthday in the Cayman Islands was announced
 🎁 add sources to the holiday definitions and test cases of above countries/territories (at least that I could easily find again and make sense to add)

For the Bahamas, unfortunately, I still cannot find any information on when they have public holidays. Therefore I was unable to check the dates.

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
