### PR TITLE
Add new holiday type bank and rename official holiday to public holiday

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,40 @@ To access the public holidays of a subdivision of a country, e.g. Baden-Württem
 | Subdivisions ([ISO 3166-2])    | Yes       |
 | City Holiday                   | Yes       |
 
+## Holiday types
+
+The following holiday types are supported:
+
+**Public Holiday**  
+Public holidays are days when most of the public enjoys a paid non-working days. These days are determined by local laws
+and regulations. Countries use various names for these official non-working days, such as:
+
+| Other Names for Public Holiday | Country          | Businesses |
+|--------------------------------|------------------|------------|
+| Bank Holiday                   | United Kingdom   | Closed     |
+| National Holiday               | Most Countries   | Closed     |
+| Red Days                       | Norway           | Closed     |
+| Regular Holidays               | Philippines      | Closed     |
+| Restricted Holidays            | India            | Closed     |
+| Statutory Holiday              | Canada           | Closed     |
+
+We will declare all of these as **Public Holiday**
+
+**Bank Holiday**  
+Bank holidays are days when financial institutions and government offices (and government-regulated businesses)
+are closed as determined by local laws and regulations. Other businesses, such as offices and retail stores,
+may also be closed on these days, though are not mandated to by local laws and regulations.
+
+**Observance**  
+Observance, is a celebration or commemoration that doesn't include a day off from work. When people celebrate or
+commemorate something, but do not have a day off from work for that reason, we call it an observance.
+There are different types of observance like Religious, Secular, Awareness, International or National observance.
+We will declare all of these as **Observance**
+
+**Unofficial Holidays**  
+Holidays which are not public or bank holidays. Unofficial holidays are deprecated and will be replaced by the other types over time.
+
+
 ## Development
 
 If you want to **support** us at the development on **jollyday** than take a look at [Contributing to jollyday](./CONTRIBUTING.md).

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/HolidayType.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/HolidayType.java
@@ -1,26 +1,17 @@
 package de.focus_shift.jollyday.core;
 
 /**
- * Type of holiday. Each holiday can be placed in a category and this is
- * represented by this type. The categories can mark a holiday as a official
- * holiday or not.
+ * Type of holiday.
+ * Each holiday can be placed in a category and this is represented by this type.
  */
 public enum HolidayType {
 
-  OFFICIAL_HOLIDAY {
-    @Override
-    public boolean isOfficialHoliday() {
-      return true;
-    }
-  },
+  PUBLIC_HOLIDAY,
 
-  UNOFFICIAL_HOLIDAY {
-    @Override
-    public boolean isOfficialHoliday() {
-      return false;
-    }
-  };
+  BANK_HOLIDAY,
 
-  public abstract boolean isOfficialHoliday();
+  OBSERVANCE,
 
+  @Deprecated(since = "0.31.0", forRemoval = true)
+  UNOFFICIAL_HOLIDAY;
 }

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/JapaneseHolidayManager.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/JapaneseHolidayManager.java
@@ -49,7 +49,7 @@ public class JapaneseHolidayManager extends DefaultHolidayManager {
       final LocalDate twoDaysLater = holiday.getDate().plusDays(2);
       if (CalendarUtil.contains(holidays, twoDaysLater)) {
         final LocalDate bridgingDate = twoDaysLater.minusDays(1);
-        additionalHolidays.add(new Holiday(bridgingDate, BRIDGING_HOLIDAY_PROPERTIES_KEY, HolidayType.OFFICIAL_HOLIDAY));
+        additionalHolidays.add(new Holiday(bridgingDate, BRIDGING_HOLIDAY_PROPERTIES_KEY, HolidayType.PUBLIC_HOLIDAY));
       }
     }
     holidays.addAll(additionalHolidays);

--- a/jollyday-core/src/main/resources/focus_shift.de/jollyday/schema/holiday/holiday.xsd
+++ b/jollyday-core/src/main/resources/focus_shift.de/jollyday/schema/holiday/holiday.xsd
@@ -192,7 +192,9 @@
 
   <xsd:simpleType name="HolidayType">
     <xsd:restriction base="xsd:string">
-      <xsd:enumeration value="OFFICIAL_HOLIDAY"/>
+      <xsd:enumeration value="PUBLIC_HOLIDAY"/>
+      <xsd:enumeration value="BANK_HOLIDAY"/>
+      <xsd:enumeration value="OBSERVANCE"/>
       <xsd:enumeration value="UNOFFICIAL_HOLIDAY"/>
     </xsd:restriction>
   </xsd:simpleType>
@@ -238,7 +240,7 @@
     <xsd:attribute name="validTo" type="xsd:int"/>
     <xsd:attribute name="every" type="HolidayCycleType" default="EVERY_YEAR"/>
     <xsd:attribute name="descriptionPropertiesKey" type="xsd:string"/>
-    <xsd:attribute name="localizedType" type="HolidayType" default="OFFICIAL_HOLIDAY"/>
+    <xsd:attribute name="localizedType" type="HolidayType" default="PUBLIC_HOLIDAY"/>
   </xsd:complexType>
 
   <xsd:simpleType name="Substituted">

--- a/jollyday-core/src/test/java/de/focus_shift/jollyday/core/HolidayTest.java
+++ b/jollyday-core/src/test/java/de/focus_shift/jollyday/core/HolidayTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.util.Locale;
 
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.HolidayType.UNOFFICIAL_HOLIDAY;
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.GERMAN;
@@ -15,28 +15,28 @@ class HolidayTest {
 
   @Test
   void testComparable() {
-    final Holiday holiday = new Holiday(LocalDate.of(2015, 1, 1), null, OFFICIAL_HOLIDAY);
+    final Holiday holiday = new Holiday(LocalDate.of(2015, 1, 1), null, PUBLIC_HOLIDAY);
     assertThat(holiday).isInstanceOf(Comparable.class);
   }
 
   @Test
   void testCompareToLess() {
-    final Holiday newYear = new Holiday(LocalDate.of(2015, 1, 1), null, OFFICIAL_HOLIDAY);
-    final Holiday christmas = new Holiday(LocalDate.of(2015, 12, 25), null, OFFICIAL_HOLIDAY);
+    final Holiday newYear = new Holiday(LocalDate.of(2015, 1, 1), null, PUBLIC_HOLIDAY);
+    final Holiday christmas = new Holiday(LocalDate.of(2015, 12, 25), null, PUBLIC_HOLIDAY);
     assertThat(newYear).isLessThan(christmas);
   }
 
   @Test
   void testCompareToGreater() {
-    final Holiday christmas = new Holiday(LocalDate.of(2015, 12, 25), null, OFFICIAL_HOLIDAY);
-    final Holiday newYear = new Holiday(LocalDate.of(2015, 1, 1), null, OFFICIAL_HOLIDAY);
+    final Holiday christmas = new Holiday(LocalDate.of(2015, 12, 25), null, PUBLIC_HOLIDAY);
+    final Holiday newYear = new Holiday(LocalDate.of(2015, 1, 1), null, PUBLIC_HOLIDAY);
     assertThat(christmas).isGreaterThan(newYear);
   }
 
   @Test
   void testCompareToEqual() {
-    final Holiday firstDayOfYear = new Holiday(LocalDate.of(2015, 1, 1), null, OFFICIAL_HOLIDAY);
-    final Holiday newYear = new Holiday(LocalDate.of(2015, 1, 1), null, OFFICIAL_HOLIDAY);
+    final Holiday firstDayOfYear = new Holiday(LocalDate.of(2015, 1, 1), null, PUBLIC_HOLIDAY);
+    final Holiday newYear = new Holiday(LocalDate.of(2015, 1, 1), null, PUBLIC_HOLIDAY);
     assertThat(firstDayOfYear).isEqualByComparingTo(newYear);
   }
 
@@ -44,7 +44,7 @@ class HolidayTest {
   void testHolidayDescription() {
     Locale.setDefault(ENGLISH);
 
-    final Holiday holiday = new Holiday(LocalDate.of(2011, 2, 2), "CHRISTMAS", OFFICIAL_HOLIDAY);
+    final Holiday holiday = new Holiday(LocalDate.of(2011, 2, 2), "CHRISTMAS", PUBLIC_HOLIDAY);
     assertThat(holiday.getDescription()).isEqualTo("Christmas");
     assertThat(holiday.getDescription(GERMAN)).isEqualTo("Weihnachten");
     assertThat(holiday.getDescription(new Locale("nl"))).isEqualTo("Kerstmis");
@@ -52,16 +52,16 @@ class HolidayTest {
 
   @Test
   void testHolidayEquals() {
-    final Holiday h1 = new Holiday(LocalDate.of(2011, 2, 2), "CHRISTMAS", OFFICIAL_HOLIDAY);
+    final Holiday h1 = new Holiday(LocalDate.of(2011, 2, 2), "CHRISTMAS", PUBLIC_HOLIDAY);
     assertThat(h1).isEqualTo(h1);
 
-    final Holiday h2b = new Holiday(LocalDate.of(2011, 2, 2), "CHRISTMAS", OFFICIAL_HOLIDAY);
+    final Holiday h2b = new Holiday(LocalDate.of(2011, 2, 2), "CHRISTMAS", PUBLIC_HOLIDAY);
     assertThat(h1).isEqualTo(h2b);
 
-    final Holiday h2 = new Holiday(LocalDate.of(2011, 2, 1), "CHRISTMAS", OFFICIAL_HOLIDAY);
+    final Holiday h2 = new Holiday(LocalDate.of(2011, 2, 1), "CHRISTMAS", PUBLIC_HOLIDAY);
     assertThat(h1).isNotEqualTo(h2);
 
-    final Holiday h3 = new Holiday(LocalDate.of(2011, 2, 2), "NEW_YEAR", OFFICIAL_HOLIDAY);
+    final Holiday h3 = new Holiday(LocalDate.of(2011, 2, 2), "NEW_YEAR", PUBLIC_HOLIDAY);
     assertThat(h1).isNotEqualTo(h3);
 
     final Holiday h4 = new Holiday(LocalDate.of(2011, 2, 2), "CHRISTMAS", UNOFFICIAL_HOLIDAY);

--- a/jollyday-core/src/test/java/de/focus_shift/jollyday/core/parser/functions/CreateHolidayTest.java
+++ b/jollyday-core/src/test/java/de/focus_shift/jollyday/core/parser/functions/CreateHolidayTest.java
@@ -23,14 +23,14 @@ class CreateHolidayTest {
 
       @Override
       public HolidayType officiality() {
-        return HolidayType.OFFICIAL_HOLIDAY;
+        return HolidayType.PUBLIC_HOLIDAY;
       }
     };
 
     final Holiday holiday = new CreateHoliday(LocalDate.of(2020, 4, 1)).apply(described);
 
     assertThat(holiday.getDate()).hasYear(2020).hasMonth(APRIL).hasDayOfMonth(1);
-    assertThat(holiday.getType()).isEqualTo(HolidayType.OFFICIAL_HOLIDAY);
+    assertThat(holiday.getType()).isEqualTo(HolidayType.PUBLIC_HOLIDAY);
     assertThat(holiday.getPropertiesKey()).isEqualTo("propertiesKey");
   }
 }

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonChristianHoliday.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonChristianHoliday.java
@@ -43,7 +43,7 @@ public class JacksonChristianHoliday implements ChristianHoliday {
   @Override
   public HolidayType officiality() {
     return christianHoliday.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(christianHoliday.getLocalizedType().name());
   }
 

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonEthiopianOrthodoxHoliday.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonEthiopianOrthodoxHoliday.java
@@ -23,7 +23,7 @@ public class JacksonEthiopianOrthodoxHoliday implements EthiopianOrthodoxHoliday
   @Override
   public HolidayType officiality() {
     return ethiopianOrthodoxHoliday.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(ethiopianOrthodoxHoliday.getLocalizedType().name());
   }
 

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonFixed.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonFixed.java
@@ -35,7 +35,7 @@ public class JacksonFixed implements Fixed {
   @Override
   public HolidayType officiality() {
     return fixed.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(fixed.getLocalizedType().name());
   }
 

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonFixedWeekdayBetweenFixed.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonFixedWeekdayBetweenFixed.java
@@ -40,7 +40,7 @@ public class JacksonFixedWeekdayBetweenFixed implements FixedWeekdayBetweenFixed
   @Override
   public HolidayType officiality() {
     return fixedWeekdayBetweenFixed.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(fixedWeekdayBetweenFixed.getLocalizedType().name());
   }
 

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonFixedWeekdayInMonth.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonFixedWeekdayInMonth.java
@@ -40,7 +40,7 @@ public class JacksonFixedWeekdayInMonth implements FixedWeekdayInMonth {
   @Override
   public HolidayType officiality() {
     return fixedWeekdayInMonth.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(fixedWeekdayInMonth.getLocalizedType().name());
   }
 

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonFixedWeekdayRelativeToFixed.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonFixedWeekdayRelativeToFixed.java
@@ -47,7 +47,7 @@ public class JacksonFixedWeekdayRelativeToFixed implements FixedWeekdayRelativeT
   @Override
   public HolidayType officiality() {
     return fixedWeekdayRelativeToFixed.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(fixedWeekdayRelativeToFixed.getLocalizedType().name());
   }
 

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonIslamicHoliday.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonIslamicHoliday.java
@@ -33,7 +33,7 @@ public class JacksonIslamicHoliday implements IslamicHoliday {
   @Override
   public HolidayType officiality() {
     return islamicHoliday.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(islamicHoliday.getLocalizedType().name());
   }
 

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonRelativeToEasterSunday.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonRelativeToEasterSunday.java
@@ -27,7 +27,7 @@ public class JacksonRelativeToEasterSunday implements RelativeToEasterSunday {
   @Override
   public HolidayType officiality() {
     return relativeToEasterSunday.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(relativeToEasterSunday.getLocalizedType().name());
   }
 

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonRelativeToFixed.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonRelativeToFixed.java
@@ -52,7 +52,7 @@ public class JacksonRelativeToFixed implements RelativeToFixed {
   @Override
   public HolidayType officiality() {
     return relativeToFixed.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(relativeToFixed.getLocalizedType().name());
   }
 

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonRelativeToWeekdayInMonth.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonRelativeToWeekdayInMonth.java
@@ -41,7 +41,7 @@ public class JacksonRelativeToWeekdayInMonth implements RelativeToWeekdayInMonth
   @Override
   public HolidayType officiality() {
     return relativeToWeekdayInMonth.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(relativeToWeekdayInMonth.getLocalizedType().name());
   }
 

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/mapping/Holiday.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/mapping/Holiday.java
@@ -107,7 +107,7 @@ public abstract class Holiday {
    */
   public HolidayType getLocalizedType() {
     if (localizedType == null) {
-      return HolidayType.OFFICIAL_HOLIDAY;
+      return HolidayType.PUBLIC_HOLIDAY;
     } else {
       return localizedType;
     }

--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/mapping/HolidayType.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/mapping/HolidayType.java
@@ -2,7 +2,9 @@ package de.focus_shift.jollyday.jackson.mapping;
 
 public enum HolidayType {
 
-  OFFICIAL_HOLIDAY,
+  PUBLIC_HOLIDAY,
+  BANK_HOLIDAY,
+  OBSERVANCE,
   UNOFFICIAL_HOLIDAY;
 
   public String value() {

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbChristianHoliday.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbChristianHoliday.java
@@ -44,7 +44,7 @@ public class JaxbChristianHoliday implements ChristianHoliday {
   @Override
   public HolidayType officiality() {
     return christianHoliday.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(christianHoliday.getLocalizedType().name());
   }
 

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbEthiopianOrthodoxHoliday.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbEthiopianOrthodoxHoliday.java
@@ -23,7 +23,7 @@ public class JaxbEthiopianOrthodoxHoliday implements EthiopianOrthodoxHoliday {
   @Override
   public HolidayType officiality() {
     return ethiopianOrthodoxHoliday.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(ethiopianOrthodoxHoliday.getLocalizedType().name());
   }
 

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbFixed.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbFixed.java
@@ -35,7 +35,7 @@ public class JaxbFixed implements Fixed {
   @Override
   public HolidayType officiality() {
     return fixed.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(fixed.getLocalizedType().name());
   }
 

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbFixedWeekdayBetweenFixed.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbFixedWeekdayBetweenFixed.java
@@ -40,7 +40,7 @@ public class JaxbFixedWeekdayBetweenFixed implements FixedWeekdayBetweenFixed {
   @Override
   public HolidayType officiality() {
     return fixedWeekdayBetweenFixed.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(fixedWeekdayBetweenFixed.getLocalizedType().name());
   }
 

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbFixedWeekdayInMonth.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbFixedWeekdayInMonth.java
@@ -40,7 +40,7 @@ public class JaxbFixedWeekdayInMonth implements FixedWeekdayInMonth {
   @Override
   public HolidayType officiality() {
     return fixedWeekdayInMonth.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(fixedWeekdayInMonth.getLocalizedType().name());
   }
 

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbFixedWeekdayRelativeToFixed.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbFixedWeekdayRelativeToFixed.java
@@ -47,7 +47,7 @@ public class JaxbFixedWeekdayRelativeToFixed implements FixedWeekdayRelativeToFi
   @Override
   public HolidayType officiality() {
     return fixedWeekdayRelativeToFixed.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(fixedWeekdayRelativeToFixed.getLocalizedType().name());
   }
 

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbIslamicHoliday.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbIslamicHoliday.java
@@ -33,7 +33,7 @@ public class JaxbIslamicHoliday implements IslamicHoliday {
   @Override
   public HolidayType officiality() {
     return islamicHoliday.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(islamicHoliday.getLocalizedType().name());
   }
 

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbRelativeToEasterSunday.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbRelativeToEasterSunday.java
@@ -28,7 +28,7 @@ public class JaxbRelativeToEasterSunday implements RelativeToEasterSunday {
   @Override
   public HolidayType officiality() {
     return relativeToEasterSunday.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(relativeToEasterSunday.getLocalizedType().name());
   }
 

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbRelativeToFixed.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbRelativeToFixed.java
@@ -52,7 +52,7 @@ public class JaxbRelativeToFixed implements RelativeToFixed {
   @Override
   public HolidayType officiality() {
     return relativeToFixed.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(relativeToFixed.getLocalizedType().name());
   }
 

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbRelativeToWeekdayInMonth.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbRelativeToWeekdayInMonth.java
@@ -41,7 +41,7 @@ public class JaxbRelativeToWeekdayInMonth implements RelativeToWeekdayInMonth {
   @Override
   public HolidayType officiality() {
     return relativeToWeekdayInMonth.getLocalizedType() == null
-      ? HolidayType.OFFICIAL_HOLIDAY
+      ? HolidayType.PUBLIC_HOLIDAY
       : HolidayType.valueOf(relativeToWeekdayInMonth.getLocalizedType().name());
   }
 

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/HolidayManagerTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/HolidayManagerTest.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.GERMANY;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.HolidayType.UNOFFICIAL_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.APRIL;
@@ -123,7 +123,7 @@ class HolidayManagerTest {
     calendar.set(MONTH, Calendar.JANUARY);
     calendar.set(DAY_OF_MONTH, 4);
     assertThat(sut.isHoliday(calendar, UNOFFICIAL_HOLIDAY)).isTrue();
-    assertThat(sut.isHoliday(calendar, OFFICIAL_HOLIDAY)).isFalse();
+    assertThat(sut.isHoliday(calendar, PUBLIC_HOLIDAY)).isFalse();
   }
 
   @Test
@@ -136,7 +136,7 @@ class HolidayManagerTest {
   @Test
   void ensureIsHolidayMethodReturnsTrueFalseForLocalDateWithHolidayType() {
     final HolidayManager sut = HolidayManager.getInstance(create("test"));
-    assertThat(sut.isHoliday(LocalDate.of(2010, 1, 4), OFFICIAL_HOLIDAY)).isFalse();
+    assertThat(sut.isHoliday(LocalDate.of(2010, 1, 4), PUBLIC_HOLIDAY)).isFalse();
     assertThat(sut.isHoliday(LocalDate.of(2010, 1, 4), UNOFFICIAL_HOLIDAY)).isTrue();
   }
 

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayCHTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayCHTest.java
@@ -12,7 +12,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.SWITZERLAND;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JUNE;
@@ -35,7 +35,7 @@ class HolidayCHTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year, "ow");
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 25), "ST_NICHOLAS", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 25), "ST_NICHOLAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -44,7 +44,7 @@ class HolidayCHTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year, "ow");
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 25), "ST_NICHOLAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 25), "ST_NICHOLAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -53,7 +53,7 @@ class HolidayCHTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year, "ti");
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 29), "ST_PETER_PAUL", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 29), "ST_PETER_PAUL", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -62,7 +62,7 @@ class HolidayCHTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year, "ju");
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 23), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 23), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -71,6 +71,6 @@ class HolidayCHTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year, "ge");
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 31), "RESTORATION_OF_THE_REPUBLIC", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 31), "RESTORATION_OF_THE_REPUBLIC", PUBLIC_HOLIDAY));
   }
 }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayCUTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayCUTest.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.CUBA;
 import static de.focus_shift.jollyday.core.HolidayCalendar.FINLAND;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
@@ -29,7 +29,7 @@ class HolidayCUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "TRIUMPH_OF_THE_REVOLUTION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "TRIUMPH_OF_THE_REVOLUTION", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -38,7 +38,7 @@ class HolidayCUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "VICTORY_OF_FIDEL_CASTRO", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "VICTORY_OF_FIDEL_CASTRO", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -47,7 +47,7 @@ class HolidayCUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -56,9 +56,9 @@ class HolidayCUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 25), "DAY_BEFORE_THE_COMMEMORATION_OF_THE_ASSAULT_OF_THE_MONCADA_GARRISON", OFFICIAL_HOLIDAY))
-      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 26), "COMMEMORATION_OF_THE_ASSAULT_OF_THE_MONCADA_GARRISON", OFFICIAL_HOLIDAY))
-      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 27), "DAY_AFTER_THE_COMMEMORATION_OF_THE_ASSAULT_OF_THE_MONCADA_GARRISON", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 25), "DAY_BEFORE_THE_COMMEMORATION_OF_THE_ASSAULT_OF_THE_MONCADA_GARRISON", PUBLIC_HOLIDAY))
+      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 26), "COMMEMORATION_OF_THE_ASSAULT_OF_THE_MONCADA_GARRISON", PUBLIC_HOLIDAY))
+      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 27), "DAY_AFTER_THE_COMMEMORATION_OF_THE_ASSAULT_OF_THE_MONCADA_GARRISON", PUBLIC_HOLIDAY));
 
   }
 
@@ -68,7 +68,7 @@ class HolidayCUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 10), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 10), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -77,7 +77,7 @@ class HolidayCUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayCZTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayCZTest.java
@@ -11,7 +11,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.CZECH_REPUBLIC;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
@@ -30,7 +30,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -39,7 +39,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -48,7 +48,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 8), "LIBERATION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 8), "LIBERATION", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -57,7 +57,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 5), "CYRUS_METHODIUS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 5), "CYRUS_METHODIUS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -66,7 +66,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 6), "HUS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 6), "HUS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -75,7 +75,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 28), "WENCELAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 28), "WENCELAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -84,7 +84,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 28), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 28), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -93,7 +93,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 17), "FREEDOM_DEMOCRACY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 17), "FREEDOM_DEMOCRACY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -102,7 +102,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 24), "CHRISTMAS_EVE", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 24), "CHRISTMAS_EVE", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -111,7 +111,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -120,7 +120,7 @@ class HolidayCZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", PUBLIC_HOLIDAY));
   }
 
   @Property

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayDKTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayDKTest.java
@@ -12,7 +12,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.DENMARK;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
@@ -27,7 +27,7 @@ class HolidayDKTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -36,8 +36,8 @@ class HolidayDKTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY))
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY))
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", PUBLIC_HOLIDAY));
   }
 
   @Test
@@ -47,7 +47,7 @@ class HolidayDKTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays2023 = holidayManagerDK.getHolidays(Year.of(2023));
     assertThat(holidays2023)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(2023, MAY, 5), "christian.GENERAL_PRAYER_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2023, MAY, 5), "christian.GENERAL_PRAYER_DAY", PUBLIC_HOLIDAY));
 
     final Set<Holiday> holidays2024 = holidayManagerDK.getHolidays(Year.of(2024));
     assertThat(holidays2024)

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayFITest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayFITest.java
@@ -12,7 +12,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.FINLAND;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
@@ -36,7 +36,7 @@ class HolidayFITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -45,7 +45,7 @@ class HolidayFITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 6), "EPIPHANY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 6), "EPIPHANY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -54,7 +54,7 @@ class HolidayFITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -63,7 +63,7 @@ class HolidayFITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 6), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 6), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -72,9 +72,9 @@ class HolidayFITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 24), "CHRISTMAS_EVE", OFFICIAL_HOLIDAY))
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY))
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 24), "CHRISTMAS_EVE", PUBLIC_HOLIDAY))
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY))
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -123,7 +123,7 @@ class HolidayFITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year, "01");
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 9), "SELF_GOVERNANCE", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 9), "SELF_GOVERNANCE", PUBLIC_HOLIDAY));
   }
 
   @Property

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayGBTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayGBTest.java
@@ -12,7 +12,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.UNITED_KINGDOM;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.MAY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,7 +34,7 @@ class HolidayGBTest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2023 = holidayManagerGB.getHolidays(Year.of(2023));
     assertThat(holidays2023)
-      .contains(new Holiday(LocalDate.of(2023, MAY, 8), "KINGS_CORONATION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2023, MAY, 8), "KINGS_CORONATION", PUBLIC_HOLIDAY));
 
     final Set<Holiday> holidays2024 = holidayManagerGB.getHolidays(Year.of(2024));
     assertThat(holidays2024)

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayGETest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayGETest.java
@@ -11,7 +11,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.GEORGIA;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.APRIL;
 import static java.time.Month.AUGUST;
@@ -30,8 +30,8 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY))
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY))
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -40,7 +40,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 7), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 7), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -49,7 +49,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 19), "EPIPHANY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 19), "EPIPHANY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -58,7 +58,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MARCH, 3), "MOTHERS_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MARCH, 3), "MOTHERS_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -67,7 +67,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MARCH, 8), "INTERNATIONAL_WOMAN", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MARCH, 8), "INTERNATIONAL_WOMAN", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -76,7 +76,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), APRIL, 9), "NATIONAL_UNITY_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), APRIL, 9), "NATIONAL_UNITY_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -85,7 +85,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 9), "DAY_OF_VICTORY_OVER_FASCISM", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 9), "DAY_OF_VICTORY_OVER_FASCISM", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -94,7 +94,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 12), "ST_ANDREW_FIRST_CALLED_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 12), "ST_ANDREW_FIRST_CALLED_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -103,7 +103,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 26), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 26), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -112,7 +112,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 28), "ST_MARY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 28), "ST_MARY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -121,7 +121,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 14), "DAY_OF_SVETITSKHOVELI_CATHEDRA", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 14), "DAY_OF_SVETITSKHOVELI_CATHEDRA", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -130,7 +130,7 @@ class HolidayGETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 23), "ST_GEORGE", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 23), "ST_GEORGE", PUBLIC_HOLIDAY));
   }
 
   @Property

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayGGTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayGGTest.java
@@ -12,7 +12,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.GUERNSEY;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.MAY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +33,7 @@ class HolidayGGTest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2023 = holidayManager.getHolidays(Year.of(2023));
     assertThat(holidays2023)
-      .contains(new Holiday(LocalDate.of(2023, MAY, 8), "KINGS_CORONATION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2023, MAY, 8), "KINGS_CORONATION", PUBLIC_HOLIDAY));
 
     final Set<Holiday> holidays2024 = holidayManager.getHolidays(Year.of(2024));
     assertThat(holidays2024)

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayHRTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayHRTest.java
@@ -11,7 +11,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.CROATIA;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.AUGUST;
 import static java.time.Month.DECEMBER;
@@ -30,7 +30,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -39,7 +39,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -48,7 +48,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 30), "NATIONAL_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 30), "NATIONAL_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -57,7 +57,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 30), "NATIONAL_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 30), "NATIONAL_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -66,7 +66,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 22), "ANTI_FASCIST", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 22), "ANTI_FASCIST", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -75,7 +75,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JUNE, 25), "STATEHOOD", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JUNE, 25), "STATEHOOD", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -84,7 +84,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 25), "STATEHOOD", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 25), "STATEHOOD", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -93,7 +93,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JUNE, 25), "STATEHOOD", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JUNE, 25), "STATEHOOD", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -102,7 +102,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 5), "VICTORY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 5), "VICTORY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -111,7 +111,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_MARY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_MARY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -120,7 +120,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 8), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 8), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -129,7 +129,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 8), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 8), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -138,7 +138,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 8), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 8), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -147,7 +147,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 1), "ALL_SAINTS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 1), "ALL_SAINTS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -156,7 +156,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 18), "REMEMBRANCE", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 18), "REMEMBRANCE", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -165,7 +165,7 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 18), "REMEMBRANCE", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 18), "REMEMBRANCE", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -174,8 +174,8 @@ class HolidayHRTest {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY))
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY))
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", PUBLIC_HOLIDAY));
   }
 
   @Property

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayIETest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayIETest.java
@@ -12,7 +12,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.IRELAND;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.FEBRUARY;
@@ -28,7 +28,7 @@ class HolidayIETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -37,7 +37,7 @@ class HolidayIETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MARCH, 17), "ST_PATRICK", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MARCH, 17), "ST_PATRICK", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -46,7 +46,7 @@ class HolidayIETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -55,7 +55,7 @@ class HolidayIETest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -104,7 +104,7 @@ class HolidayIETest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2023 = holidayManagerIE.getHolidays(Year.of(2023));
     assertThat(holidays2023)
-      .contains(new Holiday(LocalDate.of(2023, FEBRUARY, 6), "ST_BRIGID", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2023, FEBRUARY, 6), "ST_BRIGID", PUBLIC_HOLIDAY));
   }
 
   @Test
@@ -113,7 +113,7 @@ class HolidayIETest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2024 = holidayManagerIE.getHolidays(Year.of(2024));
     assertThat(holidays2024)
-      .contains(new Holiday(LocalDate.of(2024, FEBRUARY, 5), "ST_BRIGID", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2024, FEBRUARY, 5), "ST_BRIGID", PUBLIC_HOLIDAY));
   }
 
   @Test
@@ -122,7 +122,7 @@ class HolidayIETest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2025 = holidayManagerIE.getHolidays(Year.of(2025));
     assertThat(holidays2025)
-      .contains(new Holiday(LocalDate.of(2025, FEBRUARY, 3), "ST_BRIGID", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2025, FEBRUARY, 3), "ST_BRIGID", PUBLIC_HOLIDAY));
   }
 
   @Test
@@ -131,7 +131,7 @@ class HolidayIETest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2026 = holidayManagerIE.getHolidays(Year.of(2026));
     assertThat(holidays2026)
-      .contains(new Holiday(LocalDate.of(2026, FEBRUARY, 2), "ST_BRIGID", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2026, FEBRUARY, 2), "ST_BRIGID", PUBLIC_HOLIDAY));
   }
 
   @Test
@@ -140,7 +140,7 @@ class HolidayIETest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2027 = holidayManagerIE.getHolidays(Year.of(2027));
     assertThat(holidays2027)
-      .contains(new Holiday(LocalDate.of(2027, FEBRUARY, 1), "ST_BRIGID", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2027, FEBRUARY, 1), "ST_BRIGID", PUBLIC_HOLIDAY));
   }
 
   @Test
@@ -149,7 +149,7 @@ class HolidayIETest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2028 = holidayManagerIE.getHolidays(Year.of(2028));
     assertThat(holidays2028)
-      .contains(new Holiday(LocalDate.of(2028, FEBRUARY, 7), "ST_BRIGID", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2028, FEBRUARY, 7), "ST_BRIGID", PUBLIC_HOLIDAY));
   }
 
   @Test
@@ -158,6 +158,6 @@ class HolidayIETest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2030 = holidayManagerIE.getHolidays(Year.of(2030));
     assertThat(holidays2030)
-      .contains(new Holiday(LocalDate.of(2030, FEBRUARY, 1), "ST_BRIGID", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2030, FEBRUARY, 1), "ST_BRIGID", PUBLIC_HOLIDAY));
   }
 }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayIMTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayIMTest.java
@@ -12,7 +12,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.ISLE_OF_MAN;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.MAY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +33,7 @@ class HolidayIMTest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2023 = holidayManager.getHolidays(Year.of(2023));
     assertThat(holidays2023)
-      .contains(new Holiday(LocalDate.of(2023, MAY, 8), "KINGS_CORONATION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2023, MAY, 8), "KINGS_CORONATION", PUBLIC_HOLIDAY));
 
     final Set<Holiday> holidays2024 = holidayManager.getHolidays(Year.of(2024));
     assertThat(holidays2024)

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayITTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayITTest.java
@@ -11,7 +11,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.ITALY;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.APRIL;
 import static java.time.Month.AUGUST;
@@ -30,7 +30,7 @@ class HolidayITTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 6), "EPIPHANY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 6), "EPIPHANY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -39,7 +39,7 @@ class HolidayITTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), APRIL, 25), "LIBERATION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), APRIL, 25), "LIBERATION", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -48,7 +48,7 @@ class HolidayITTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -57,7 +57,7 @@ class HolidayITTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 2), "REPUBLIC_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 2), "REPUBLIC_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -66,7 +66,7 @@ class HolidayITTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -75,7 +75,7 @@ class HolidayITTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 1), "ALL_SAINTS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 1), "ALL_SAINTS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -84,7 +84,7 @@ class HolidayITTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 8), "IMMACULATE_CONCEPTION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 8), "IMMACULATE_CONCEPTION", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -93,8 +93,8 @@ class HolidayITTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY))
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY))
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -103,7 +103,7 @@ class HolidayITTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -112,7 +112,7 @@ class HolidayITTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayJETest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayJETest.java
@@ -12,7 +12,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.JERSEY;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.MAY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +33,7 @@ class HolidayJETest extends AbstractCountryTestBase {
 
     final Set<Holiday> holidays2023 = holidayManager.getHolidays(Year.of(2023));
     assertThat(holidays2023)
-      .contains(new Holiday(LocalDate.of(2023, MAY, 8), "KINGS_CORONATION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(2023, MAY, 8), "KINGS_CORONATION", PUBLIC_HOLIDAY));
 
     final Set<Holiday> holidays2024 = holidayManager.getHolidays(Year.of(2024));
     assertThat(holidays2024)

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayLITest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayLITest.java
@@ -11,7 +11,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.LIECHTENSTEIN;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.AUGUST;
 import static java.time.Month.DECEMBER;
@@ -31,7 +31,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -40,7 +40,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -49,7 +49,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 6), "EPIPHANY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 6), "EPIPHANY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -58,7 +58,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), FEBRUARY, 2), "CANDLEMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), FEBRUARY, 2), "CANDLEMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -67,7 +67,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MARCH, 19), "ST_JOSEPH", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MARCH, 19), "ST_JOSEPH", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -76,7 +76,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "MAY_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "MAY_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -85,7 +85,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -94,7 +94,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 8), "NATIVITY_LADY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 8), "NATIVITY_LADY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -103,7 +103,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 1), "ALL_SAINTS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 1), "ALL_SAINTS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -112,7 +112,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 8), "IMMACULATE_CONCEPTION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 8), "IMMACULATE_CONCEPTION", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -121,7 +121,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -130,7 +130,7 @@ class HolidayLITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", PUBLIC_HOLIDAY));
   }
 
   @Property

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayLUTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayLUTest.java
@@ -11,7 +11,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.LUXEMBOURG;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.AUGUST;
 import static java.time.Month.DECEMBER;
@@ -30,7 +30,7 @@ class HolidayLUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -39,7 +39,7 @@ class HolidayLUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -48,7 +48,7 @@ class HolidayLUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 9), "EUROPE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 9), "EUROPE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -57,7 +57,7 @@ class HolidayLUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 9), "EUROPE_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 9), "EUROPE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -66,7 +66,7 @@ class HolidayLUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 23), "NATIONAL_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 23), "NATIONAL_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -75,7 +75,7 @@ class HolidayLUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -84,7 +84,7 @@ class HolidayLUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 1), "ALL_SAINTS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 1), "ALL_SAINTS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -93,7 +93,7 @@ class HolidayLUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -102,7 +102,7 @@ class HolidayLUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "STEPHENS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -141,6 +141,6 @@ class HolidayLUTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year, "lu", "clu");
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), FEBRUARY, 15), "CARNIVAL", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), FEBRUARY, 15), "CARNIVAL", PUBLIC_HOLIDAY));
   }
 }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayMATest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayMATest.java
@@ -11,7 +11,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.MOROCCO;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.AUGUST;
 import static java.time.Month.JANUARY;
@@ -28,7 +28,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -37,7 +37,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 11), "PROCLAMATION_OF_INDEPENDENCE", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 11), "PROCLAMATION_OF_INDEPENDENCE", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -46,7 +46,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 14), "AMAZIGH_NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 14), "AMAZIGH_NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -55,7 +55,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 14), "AMAZIGH_NEW_YEAR", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 14), "AMAZIGH_NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -64,7 +64,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -73,7 +73,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 30), "ENTHRONEMENT", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JULY, 30), "ENTHRONEMENT", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -82,7 +82,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 14), "ZIKRA_OUED_ED_DAHAB", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 14), "ZIKRA_OUED_ED_DAHAB", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -91,7 +91,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 20), "REVOLUTION_OF_THE_KING_AND_THE_PEOPLE", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 20), "REVOLUTION_OF_THE_KING_AND_THE_PEOPLE", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -100,7 +100,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 21), "YOUTH", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 21), "YOUTH", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -109,7 +109,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 6), "GREEN_MARCH", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 6), "GREEN_MARCH", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -118,7 +118,7 @@ class HolidayMATest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 18), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 18), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayMDTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayMDTest.java
@@ -11,7 +11,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.MOLDOVA;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.AUGUST;
 import static java.time.Month.DECEMBER;
@@ -29,7 +29,7 @@ class HolidayMDTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -38,8 +38,8 @@ class HolidayMDTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 7), "CHRISTMAS_EVE", OFFICIAL_HOLIDAY))
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 8), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 7), "CHRISTMAS_EVE", PUBLIC_HOLIDAY))
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 8), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -58,7 +58,7 @@ class HolidayMDTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MARCH, 8), "INTERNATIONAL_WOMAN", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MARCH, 8), "INTERNATIONAL_WOMAN", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -67,7 +67,7 @@ class HolidayMDTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -86,7 +86,7 @@ class HolidayMDTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 1), "CHILDRENS_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 1), "CHILDRENS_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -115,7 +115,7 @@ class HolidayMDTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 9), "VICTORY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 9), "VICTORY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -134,7 +134,7 @@ class HolidayMDTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 27), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 27), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -153,7 +153,7 @@ class HolidayMDTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 31), "LANGUAGE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 31), "LANGUAGE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -172,7 +172,7 @@ class HolidayMDTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -181,6 +181,6 @@ class HolidayMDTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year, "ba");
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 22), "REGIONAL", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 22), "REGIONAL", PUBLIC_HOLIDAY));
   }
 }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayNLTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayNLTest.java
@@ -11,7 +11,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.NETHERLANDS;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
@@ -26,7 +26,7 @@ class HolidayNLTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -35,7 +35,7 @@ class HolidayNLTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -44,7 +44,7 @@ class HolidayNLTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 5), "LIBERATION", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 5), "LIBERATION", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -54,7 +54,7 @@ class HolidayNLTest extends AbstractCountryTestBase {
     if (year.getValue() % 5 == 0) {
       assertThat(holidays)
         .isNotEmpty()
-        .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 5), "LIBERATION", OFFICIAL_HOLIDAY));
+        .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 5), "LIBERATION", PUBLIC_HOLIDAY));
     }
   }
 
@@ -65,7 +65,7 @@ class HolidayNLTest extends AbstractCountryTestBase {
     if (year.getValue() % 5 != 0) {
       assertThat(holidays)
         .isNotEmpty()
-        .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 5), "LIBERATION", OFFICIAL_HOLIDAY));
+        .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 5), "LIBERATION", PUBLIC_HOLIDAY));
     }
   }
 
@@ -75,7 +75,7 @@ class HolidayNLTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 5), "LIBERATION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 5), "LIBERATION", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -84,7 +84,7 @@ class HolidayNLTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "FIRST_CHRISTMAS_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "FIRST_CHRISTMAS_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -93,7 +93,7 @@ class HolidayNLTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "SECOND_CHRISTMAS_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "SECOND_CHRISTMAS_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayNZTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayNZTest.java
@@ -12,7 +12,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.NEW_ZEALAND;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.SEPTEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,7 +57,7 @@ class HolidayNZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 26), "QUEEN_ELIZABETH_II_MEMORIAL_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 26), "QUEEN_ELIZABETH_II_MEMORIAL_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -66,7 +66,7 @@ class HolidayNZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 26), "QUEEN_ELIZABETH_II_MEMORIAL_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 26), "QUEEN_ELIZABETH_II_MEMORIAL_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -75,6 +75,6 @@ class HolidayNZTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 26), "QUEEN_ELIZABETH_II_MEMORIAL_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), SEPTEMBER, 26), "QUEEN_ELIZABETH_II_MEMORIAL_DAY", PUBLIC_HOLIDAY));
   }
 }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayROTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayROTest.java
@@ -13,7 +13,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.ROMANIA;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.AUGUST;
 import static java.time.Month.DECEMBER;
@@ -40,8 +40,8 @@ class HolidayROTest extends AbstractCountryTestBase {
     assertThat(holidays)
       .isNotEmpty()
       .contains(
-        new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY),
-        new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "NEW_YEAR", OFFICIAL_HOLIDAY)
+        new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY),
+        new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "NEW_YEAR", PUBLIC_HOLIDAY)
       );
   }
 
@@ -52,7 +52,7 @@ class HolidayROTest extends AbstractCountryTestBase {
     assertThat(holidays)
       .isNotEmpty()
       .contains(
-        new Holiday(LocalDate.of(year.getValue(), JANUARY, 6), "EPIPHANY", OFFICIAL_HOLIDAY)
+        new Holiday(LocalDate.of(year.getValue(), JANUARY, 6), "EPIPHANY", PUBLIC_HOLIDAY)
       );
   }
 
@@ -73,7 +73,7 @@ class HolidayROTest extends AbstractCountryTestBase {
     assertThat(holidays)
       .isNotEmpty()
       .contains(
-        new Holiday(LocalDate.of(year.getValue(), JANUARY, 7), "ST_JOHN", OFFICIAL_HOLIDAY)
+        new Holiday(LocalDate.of(year.getValue(), JANUARY, 7), "ST_JOHN", PUBLIC_HOLIDAY)
       );
   }
 
@@ -103,7 +103,7 @@ class HolidayROTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 24), "UNIFICATION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 24), "UNIFICATION", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -113,7 +113,7 @@ class HolidayROTest extends AbstractCountryTestBase {
     assertThat(holidays)
       .isNotEmpty()
       .contains(
-        new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY)
+        new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY)
       );
   }
 
@@ -134,7 +134,7 @@ class HolidayROTest extends AbstractCountryTestBase {
     assertThat(holidays)
       .isNotEmpty()
       .contains(
-        new Holiday(LocalDate.of(year.getValue(), JUNE, 1), "CHILDRENS_DAY", OFFICIAL_HOLIDAY)
+        new Holiday(LocalDate.of(year.getValue(), JUNE, 1), "CHILDRENS_DAY", PUBLIC_HOLIDAY)
       );
   }
 
@@ -145,7 +145,7 @@ class HolidayROTest extends AbstractCountryTestBase {
     assertThat(holidays)
       .isNotEmpty()
       .contains(
-        new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "NAVY_DAY", OFFICIAL_HOLIDAY)
+        new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "NAVY_DAY", PUBLIC_HOLIDAY)
       );
   }
 
@@ -156,7 +156,7 @@ class HolidayROTest extends AbstractCountryTestBase {
     assertThat(holidays)
       .isNotEmpty()
       .contains(
-        new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 30), "ST_ANDREW", OFFICIAL_HOLIDAY)
+        new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 30), "ST_ANDREW", PUBLIC_HOLIDAY)
       );
   }
 
@@ -167,7 +167,7 @@ class HolidayROTest extends AbstractCountryTestBase {
     assertThat(holidays)
       .isNotEmpty()
       .contains(
-        new Holiday(LocalDate.of(year.getValue(), DECEMBER, 1), "NATIONAL_DAY", OFFICIAL_HOLIDAY)
+        new Holiday(LocalDate.of(year.getValue(), DECEMBER, 1), "NATIONAL_DAY", PUBLIC_HOLIDAY)
       );
   }
 
@@ -178,8 +178,8 @@ class HolidayROTest extends AbstractCountryTestBase {
     assertThat(holidays)
       .isNotEmpty()
       .contains(
-        new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY),
-        new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "CHRISTMAS", OFFICIAL_HOLIDAY)
+        new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY),
+        new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "CHRISTMAS", PUBLIC_HOLIDAY)
       );
   }
 

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayRSTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayRSTest.java
@@ -13,7 +13,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.SERBIA;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.DayOfWeek.SUNDAY;
 import static java.time.Month.FEBRUARY;
@@ -32,7 +32,7 @@ class HolidayRSTest extends AbstractCountryTestBase {
 
     final LocalDate firstNewYear = LocalDate.of(year.getValue(), JANUARY, 1);
     final LocalDate secondNewYear = LocalDate.of(year.getValue(), JANUARY, 2);
-    checkSundayMovingToNextWorkday(holidays, firstNewYear, secondNewYear, "NEW_YEAR", OFFICIAL_HOLIDAY);
+    checkSundayMovingToNextWorkday(holidays, firstNewYear, secondNewYear, "NEW_YEAR", PUBLIC_HOLIDAY);
   }
 
   @Property
@@ -42,7 +42,7 @@ class HolidayRSTest extends AbstractCountryTestBase {
 
     final LocalDate firstStateHood = LocalDate.of(year.getValue(), FEBRUARY, 15);
     final LocalDate secondStateHood = LocalDate.of(year.getValue(), FEBRUARY, 16);
-    checkSundayMovingToNextWorkday(holidays, firstStateHood, secondStateHood, "STATEHOOD", OFFICIAL_HOLIDAY);
+    checkSundayMovingToNextWorkday(holidays, firstStateHood, secondStateHood, "STATEHOOD", PUBLIC_HOLIDAY);
   }
 
   @Property
@@ -52,7 +52,7 @@ class HolidayRSTest extends AbstractCountryTestBase {
 
     final LocalDate firstLabourDay = LocalDate.of(year.getValue(), MAY, 1);
     final LocalDate secondLabourDay = LocalDate.of(year.getValue(), MAY, 2);
-    checkSundayMovingToNextWorkday(holidays, firstLabourDay, secondLabourDay, "LABOUR_DAY", OFFICIAL_HOLIDAY);
+    checkSundayMovingToNextWorkday(holidays, firstLabourDay, secondLabourDay, "LABOUR_DAY", PUBLIC_HOLIDAY);
   }
 
   @Property
@@ -64,11 +64,11 @@ class HolidayRSTest extends AbstractCountryTestBase {
     if (isSunday(armistice)) {
       assertThat(holidays)
         .isNotEmpty()
-        .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 12), "ARMISTICE", OFFICIAL_HOLIDAY));
+        .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 12), "ARMISTICE", PUBLIC_HOLIDAY));
     } else {
       assertThat(holidays)
         .isNotEmpty()
-        .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 11), "ARMISTICE", OFFICIAL_HOLIDAY));
+        .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 11), "ARMISTICE", PUBLIC_HOLIDAY));
     }
   }
 
@@ -78,7 +78,7 @@ class HolidayRSTest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 7), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 7), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidaySITest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidaySITest.java
@@ -11,7 +11,7 @@ import java.time.Year;
 import java.util.Set;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.SLOWENIA;
-import static de.focus_shift.jollyday.core.HolidayType.OFFICIAL_HOLIDAY;
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static de.focus_shift.jollyday.core.ManagerParameters.create;
 import static java.time.Month.APRIL;
 import static java.time.Month.AUGUST;
@@ -32,7 +32,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -41,7 +41,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -50,7 +50,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -59,7 +59,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "NEW_YEAR", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 2), "NEW_YEAR", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -68,7 +68,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), FEBRUARY, 8), "PRESEREN", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), FEBRUARY, 8), "PRESEREN", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -77,7 +77,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "PRESEREN", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), JANUARY, 1), "PRESEREN", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -86,7 +86,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), APRIL, 27), "LIBERATION", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), APRIL, 27), "LIBERATION", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -95,8 +95,8 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY))
-      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 2), "LABOUR_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY))
+      .contains(new Holiday(LocalDate.of(year.getValue(), MAY, 2), "LABOUR_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -105,8 +105,8 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", OFFICIAL_HOLIDAY))
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 2), "LABOUR_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 1), "LABOUR_DAY", PUBLIC_HOLIDAY))
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), MAY, 2), "LABOUR_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -115,7 +115,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 25), "STATEHOOD", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), JUNE, 25), "STATEHOOD", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -124,7 +124,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), AUGUST, 14), "SOLIDARITY_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), AUGUST, 14), "SOLIDARITY_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -133,7 +133,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 14), "SOLIDARITY_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 14), "SOLIDARITY_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -142,7 +142,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), AUGUST, 14), "SOLIDARITY_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), AUGUST, 14), "SOLIDARITY_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -151,7 +151,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -160,7 +160,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), AUGUST, 15), "ASSUMPTION_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -169,7 +169,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 31), "REFORMATION_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 31), "REFORMATION_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -178,7 +178,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 31), "REFORMATION_DAY", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), OCTOBER, 31), "REFORMATION_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -187,7 +187,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 1), "ALL_SAINTS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), NOVEMBER, 1), "ALL_SAINTS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -196,7 +196,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -205,7 +205,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -214,7 +214,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", OFFICIAL_HOLIDAY));
+      .doesNotContain(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 25), "CHRISTMAS", PUBLIC_HOLIDAY));
   }
 
   @Property
@@ -223,7 +223,7 @@ class HolidaySITest extends AbstractCountryTestBase {
     final Set<Holiday> holidays = holidayManager.getHolidays(year);
     assertThat(holidays)
       .isNotEmpty()
-      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "INDEPENDENCE_DAY", OFFICIAL_HOLIDAY));
+      .contains(new Holiday(LocalDate.of(year.getValue(), DECEMBER, 26), "INDEPENDENCE_DAY", PUBLIC_HOLIDAY));
   }
 
   @Property


### PR DESCRIPTION
closes #462
closes #482
closes #537

Todo:
- [x] Add conclusions from [#537](https://github.com/focus-shift/jollyday/issues/537#issuecomment-2219926192) 
- [x] replace known unofficial holiday with a specific (Bank Holidays in Austria e.g.) -> we will do that later.
- [x] tests and test with Jackson and and JaxB

https://www.officeholidays.com/about/definitions

---

as described in #537 we will change the holiday types so the following:


**Public**: Public holiday
Description: Public holidays are days when most of the public enjoys a paid non-working days. These days are determined by local laws and regulations. Countries use various names for these official non-working days, such as:

| Other Names for Public Holiday | Country          | Businesses |
|--------------------------------|------------------|------------|
| Bank Holiday                   | United Kingdom   | Closed     |
| National Holiday               | Most Countries   | Closed     |
| Red Days                       | Norway           | Closed     |
| Regular Holidays               | Philippines      | Closed     |
| Restricted Holidays            | India            | Closed     |
| Statutory Holiday              | Canada           | Closed     |

We will declare all of these as **Public Holiday**

**Bank**: Bank holiday, banks and offices are closed
Description: Bank holidays are days when financial institutions and government offices (and government-regulated businesses) are closed as determined by local laws and regulations. Other businesses, such as offices and retail stores, may also be closed on these days, though are not mandated to by local laws and regulations.

**Observance** Observance, is a celebration or commemoration that doesn't include a day off from work.
Description: When people celebrate or commemorate something, but do not have a day off from work for that reason, we call it an observance. 

There are different types of observance like Religious, Secular, Awareness, International or National observance. We will declare all of these as **Observance**

**Unofficial**: Holidays which are not public or bank holidays (Deprecated)
Description: Unofficial holidays are deprecated and will be replaced by the other types over time.