### PR TITLE
Fix classloading issue when used in an OSGi environment

### DIFF
--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/ClassLoadingUtil.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/ClassLoadingUtil.java
@@ -42,6 +42,6 @@ public class ClassLoadingUtil {
    * @see Thread#currentThread()
    */
   public static ClassLoader getClassloader() {
-    return Thread.currentThread().getContextClassLoader();
+    return ClassLoadingUtil.class.getClassLoader();
   }
 }


### PR DESCRIPTION
In #438 several utils changed from instance classes to static utility classes. As a result also the way resources are read from the classpath changed. Using the current thread's context classloader is not compatible with OSGi environments because the bundle may not be accessible from the calling classloader of the calling class. In these environment calling `getClassloader` on a class in the same bundle is preferred. This should also work in other environment.