### PR TITLE
Update of Canadian holidays to include new bank holiday type.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ target/
 
 # jqwik
 .jqwik-database
+
+# VS Code IDE
+.vscode/

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions.properties
@@ -147,6 +147,7 @@ holiday.description.GALICIAN_LITERATURE                                         
 holiday.description.GANESH_CHATURTHI                                                    = Ganesh Chaturthi
 holiday.description.GENEVAN_FAST                                                        = Genevan Fast
 holiday.description.GHANDIS_BIRTHDAY                                                    = Ghandis birthday
+holiday.description.GOLD_CUP_PARADE                                                     = Gold Cup Parade
 holiday.description.GOODWILL                                                            = Day of Goodwill
 holiday.description.GOVERNMENT_CHANGE                                                   = Change of Federal Government
 holiday.description.GREEK_INDEPENDENCE_DAY                                              = Greek Independence Day
@@ -230,6 +231,7 @@ holiday.description.MOTHERS_DAY                                                 
 holiday.description.MOTHER_TERESA                                                       = Beatification of Mother Teresa
 holiday.description.MOUNTAIN_DAY                                                        = Mountain day
 holiday.description.NAEFELS_TRIP                                                        = NÃ¤fels trip
+holiday.description.NATAL_DAY                                                           = Natal Day
 holiday.description.NATIONAL_DAY                                                        = National Day
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = National day of Zumbi and black awareness
 holiday.description.NATIONAL_HEROES_DAY                                                 = National Heroes Day
@@ -337,6 +339,7 @@ holiday.description.ST_VITUS                                                    
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.TARANAKI_ANNIVERSARY                                                = Taranaki Anniversary
 holiday.description.TERRITORY_DAY                                                       = Territory Day
+holiday.description.TERRY_FOX_DAY                                                       = Terry Fox Day
 holiday.description.THAIPOOSAM_CAVEDEE                                                  = Thaipoosam Cavadee
 holiday.description.THANKSGIVING                                                        = Thanksgiving Day
 holiday.description.THEOPHANY                                                           = Theophany

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_de.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_de.properties
@@ -147,6 +147,7 @@ holiday.description.GALICIAN_LITERATURE                                         
 holiday.description.GANESH_CHATURTHI                                                    = Ganesh Chaturthi
 holiday.description.GENEVAN_FAST                                                        = Genevan Fast
 holiday.description.GHANDIS_BIRTHDAY                                                    = Ghandis Geburtstag
+holiday.description.GOLD_CUP_PARADE                                                     = Gold-Cup-Umzug
 holiday.description.GOODWILL                                                            = Tag des Wohlwollens
 holiday.description.GOVERNMENT_CHANGE                                                   = Tag des Regierungswechsels
 holiday.description.GREEK_INDEPENDENCE_DAY                                              = Griechischer Unabhängigkeitstag
@@ -230,6 +231,7 @@ holiday.description.MOTHERS_DAY                                                 
 holiday.description.MOTHER_TERESA                                                       = Seligsprechung von Mutter Teresa
 holiday.description.MOUNTAIN_DAY                                                        = Tag des Berges
 holiday.description.NAEFELS_TRIP                                                        = Näfelser Fahrt
+holiday.description.NATAL_DAY                                                           = Gründungstag
 holiday.description.NATIONAL_DAY                                                        = Nationalfeiertag
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Nationaler Tag von Zumbi und schwarzem Bewusstsein
 holiday.description.NATIONAL_HEROES_DAY                                                 = Tag der Nationalhelden
@@ -337,6 +339,7 @@ holiday.description.ST_VITUS                                                    
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.TARANAKI_ANNIVERSARY                                                = Taranaki Anniversary
 holiday.description.TERRITORY_DAY                                                       = Territorialer Tag
+holiday.description.TERRY_FOX_DAY                                                       = Terry-Fox-Tag
 holiday.description.THAIPOOSAM_CAVEDEE                                                  = Thaipoosam Cavadee
 holiday.description.THANKSGIVING                                                        = Erntedankfest
 holiday.description.THEOPHANY                                                           = Theophany

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_el.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_el.properties
@@ -147,6 +147,7 @@ holiday.description.GALICIAN_LITERATURE                                         
 holiday.description.GANESH_CHATURTHI                                                    = Γκανές Τσατούρτι
 holiday.description.GENEVAN_FAST                                                        = Γένοβα νηστεία
 holiday.description.GHANDIS_BIRTHDAY                                                    = Γενέθλια του Ghandis
+holiday.description.GOLD_CUP_PARADE                                                     = Παρέλαση χρυσού κυπέλλου
 holiday.description.GOODWILL                                                            = Ημέρα καλής θέλησης
 holiday.description.GOVERNMENT_CHANGE                                                   = Αλλαγή της ομοσπονδιακής κυβέρνησης
 holiday.description.GREEK_INDEPENDENCE_DAY                                              = Ημέρα της Ελληνικής Ανεξαρτησίας
@@ -230,6 +231,7 @@ holiday.description.MOTHERS_DAY                                                 
 holiday.description.MOTHER_TERESA                                                       = Μακαριοποίηση της Μητέρας Τερέζας
 holiday.description.MOUNTAIN_DAY                                                        = Ημέρα του βουνού
 holiday.description.NAEFELS_TRIP                                                        = Ταξίδι στο Näfels
+holiday.description.NATAL_DAY                                                           = Ημέρα γεννήσεων
 holiday.description.NATIONAL_DAY                                                        = Εθνική Ημέρα
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Εθνική Ημέρα του Ζουμπί και της Μαύρης Συνείδησης
 holiday.description.NATIONAL_HEROES_DAY                                                 = Ημέρα Εθνικών Ηρώων
@@ -337,6 +339,7 @@ holiday.description.ST_VITUS                                                    
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Καλοκαιρινές διακοπές
 holiday.description.TARANAKI_ANNIVERSARY                                                = Επέτειος Ταρανάκη
 holiday.description.TERRITORY_DAY                                                       = Ημέρα Περιοχής
+holiday.description.TERRY_FOX_DAY                                                       = Ημέρα Terry Fox
 holiday.description.THAIPOOSAM_CAVEDEE                                                  = Thaipoosam Cavadee
 holiday.description.THANKSGIVING                                                        = Ημέρα των Ευχαριστιών
 holiday.description.THEOPHANY                                                           = Θεοφάνεια

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_fr.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_fr.properties
@@ -147,6 +147,7 @@ holiday.description.GALICIAN_LITERATURE                                         
 holiday.description.GANESH_CHATURTHI                                                    = Ganesh Chaturthi
 holiday.description.GENEVAN_FAST                                                        = Jeûne Genevois
 holiday.description.GHANDIS_BIRTHDAY                                                    = Anniversaire de Gandhi
+holiday.description.GOLD_CUP_PARADE                                                     = Défilé de la Coupe d'or
 holiday.description.GOODWILL                                                            = Journée de bonne volonté
 holiday.description.GOVERNMENT_CHANGE                                                   = Changement du Gouvernement Fédéral
 holiday.description.GREEK_INDEPENDENCE_DAY                                              = Jour de l'indépendance grecque
@@ -230,6 +231,7 @@ holiday.description.MOTHERS_DAY                                                 
 holiday.description.MOTHER_TERESA                                                       = Beatification of Mother Teresa
 holiday.description.MOUNTAIN_DAY                                                        = Journée de la Montagne
 holiday.description.NAEFELS_TRIP                                                        = Voyage à Näfels
+holiday.description.NATAL_DAY                                                           = Jour de la Fondation
 holiday.description.NATIONAL_DAY                                                        = Fête Nationale
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Journéenationale de sensibilisation aux zombies et aux Noirs
 holiday.description.NATIONAL_HEROES_DAY                                                 = Journée des héros nationaux
@@ -337,6 +339,7 @@ holiday.description.ST_VITUS                                                    
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.TARANAKI_ANNIVERSARY                                                = Taranaki Anniversary
 holiday.description.TERRITORY_DAY                                                       = Journée du territoire
+holiday.description.TERRY_FOX_DAY                                                       = Jour de Terry Fox
 holiday.description.THAIPOOSAM_CAVEDEE                                                  = Thaipoosam Cavadee
 holiday.description.THANKSGIVING                                                        = Thanksgiving
 holiday.description.THEOPHANY                                                           = Theophany

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_nl.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_nl.properties
@@ -147,6 +147,7 @@ holiday.description.GALICIAN_LITERATURE                                         
 holiday.description.GANESH_CHATURTHI                                                    = Ganesh Chaturthi
 holiday.description.GENEVAN_FAST                                                        = Genevan Fast
 holiday.description.GHANDIS_BIRTHDAY                                                    = Ghandis verjaardag
+holiday.description.GOLD_CUP_PARADE                                                     = Gouden Beker Parade
 holiday.description.GOODWILL                                                            = Day van de goede wil
 holiday.description.GOVERNMENT_CHANGE                                                   = Verandering van federaal bestuur
 holiday.description.GREEK_INDEPENDENCE_DAY                                              = Griekse Onafhankelijkheidsdag
@@ -230,6 +231,7 @@ holiday.description.MOTHERS_DAY                                                 
 holiday.description.MOTHER_TERESA                                                       = Zaligverklaring van moeder Teresa
 holiday.description.MOUNTAIN_DAY                                                        = Mountain dag
 holiday.description.NAEFELS_TRIP                                                        = Näfels reis
+holiday.description.NATAL_DAY                                                           = Geboortedag
 holiday.description.NATIONAL_DAY                                                        = Nationale dag
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Nationale dag van Zumbi en zwarte bewustwording
 holiday.description.NATIONAL_HEROES_DAY                                                 = Nationale Heldendag
@@ -337,6 +339,7 @@ holiday.description.ST_VITUS                                                    
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.TARANAKI_ANNIVERSARY                                                = Taranaki Anniversary
 holiday.description.TERRITORY_DAY                                                       = Dag van het Territorium
+holiday.description.TERRY_FOX_DAY                                                       = Terry Fox Dag
 holiday.description.THAIPOOSAM_CAVEDEE                                                  = Thaipoosam Cavadee
 holiday.description.THANKSGIVING                                                        = Thanksgiving
 holiday.description.THEOPHANY                                                           = Theophanie

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_pt.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_pt.properties
@@ -147,6 +147,7 @@ holiday.description.GALICIAN_LITERATURE                                         
 holiday.description.GANESH_CHATURTHI                                                    = Ganesh Chaturthi
 holiday.description.GENEVAN_FAST                                                        = Genevan Fast
 holiday.description.GHANDIS_BIRTHDAY                                                    = Aniversário de Ghandi
+holiday.description.GOLD_CUP_PARADE                                                     = Desfile da Taça de Ouro
 holiday.description.GOODWILL                                                            = Dia da Boa Vontade
 holiday.description.GOVERNMENT_CHANGE                                                   = Change of Federal Government
 holiday.description.GREEK_INDEPENDENCE_DAY                                              = Dia da Independência da Grécia
@@ -230,6 +231,7 @@ holiday.description.MOTHERS_DAY                                                 
 holiday.description.MOTHER_TERESA                                                       = Beatificação da Madre Teresa
 holiday.description.MOUNTAIN_DAY                                                        = Dia da montanha
 holiday.description.NAEFELS_TRIP                                                        = Viagem a Näfels
+holiday.description.NATAL_DAY                                                           = Dia do nascimento
 holiday.description.NATIONAL_DAY                                                        = Dia Nacional
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Dia Nacional de Zumbi e da Consciência Negra
 holiday.description.NATIONAL_HEROES_DAY                                                 = Dia dos Heróis Nacionais
@@ -337,6 +339,7 @@ holiday.description.ST_VITUS                                                    
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.TARANAKI_ANNIVERSARY                                                = Taranaki Anniversary
 holiday.description.TERRITORY_DAY                                                       = Dia do Território
+holiday.description.TERRY_FOX_DAY                                                       = Dia de Terry Fox
 holiday.description.THAIPOOSAM_CAVEDEE                                                  = Feriado de Thaipoosam Cavadee
 holiday.description.THANKSGIVING                                                        = Dia de Dar Graças
 holiday.description.THEOPHANY                                                           = Dia da Aparição

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_sv.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_sv.properties
@@ -147,6 +147,7 @@ holiday.description.GALICIAN_LITERATURE                                         
 holiday.description.GANESH_CHATURTHI                                                    = Ganesh Chaturthi
 holiday.description.GENEVAN_FAST                                                        = Genevan Fast
 holiday.description.GHANDIS_BIRTHDAY                                                    = Ghandis birthday
+holiday.description.GOLD_CUP_PARADE                                                     = Gold Cup-paraden
 holiday.description.GOODWILL                                                            = Day of Goodwill
 holiday.description.GOVERNMENT_CHANGE                                                   = Change of Federal Government
 holiday.description.GREEK_INDEPENDENCE_DAY                                              = Greklands självständighetsdag
@@ -230,6 +231,7 @@ holiday.description.MOTHERS_DAY                                                 
 holiday.description.MOTHER_TERESA                                                       = Beatification of Mother Teresa
 holiday.description.MOUNTAIN_DAY                                                        = Mountain day
 holiday.description.NAEFELS_TRIP                                                        = Näfels resa
+holiday.description.NATAL_DAY                                                           = Natal-dagen
 holiday.description.NATIONAL_DAY                                                        = Sveriges nationaldag
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Nationella dagen för Zumbi och svart medvetenhet
 holiday.description.NATIONAL_HEROES_DAY                                                 = Nationella hjältarnas dag
@@ -337,6 +339,7 @@ holiday.description.ST_VITUS                                                    
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.TARANAKI_ANNIVERSARY                                                = Taranaki Anniversary
 holiday.description.TERRITORY_DAY                                                       = Territoriets dag
+holiday.description.TERRY_FOX_DAY                                                       = Terry Fox-dagen
 holiday.description.THAIPOOSAM_CAVEDEE                                                  = Thaipoosam Cavadee
 holiday.description.THANKSGIVING                                                        = Thanksgiving Day
 holiday.description.THEOPHANY                                                           = Theophany

--- a/jollyday-core/src/main/resources/holidays/Holidays_ca.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_ca.xml
@@ -10,9 +10,7 @@
           <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-
     <FixedWeekday which="FIRST" weekday="MONDAY" month="SEPTEMBER" descriptionPropertiesKey="LABOUR_DAY"/>
-
     <ChristianHoliday type="GOOD_FRIDAY" descriptionPropertiesKey="christian.GOOD_FRIDAY"/>
   </Holidays>
 
@@ -274,5 +272,4 @@
       <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
-
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_ca.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_ca.xml
@@ -7,7 +7,7 @@
   <Holidays>
     <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
     <Fixed month="JULY" day="1" descriptionPropertiesKey="CANADA_DAY">
-          <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
+      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     <FixedWeekday which="FIRST" weekday="MONDAY" month="SEPTEMBER" descriptionPropertiesKey="LABOUR_DAY"/>
@@ -16,7 +16,8 @@
 
   <SubConfigurations hierarchy="on" description="Ontario">
     <Holidays>
-      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"
+             localizedType="BANK_HOLIDAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE" localizedType="BANK_HOLIDAY"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
 
@@ -26,11 +27,14 @@
         <Date month="MAY" day="25"/>
       </RelativeToFixed>
 
-      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2008" descriptionPropertiesKey="FAMILY_DAY"/>
-      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="CIVIC" localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2008"
+                    descriptionPropertiesKey="FAMILY_DAY"/>
+      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="CIVIC"
+                    localizedType="BANK_HOLIDAY"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -50,13 +54,15 @@
       <FixedWeekday which="THIRD" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="DISCOVERY_DAY"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="qc" description="Quebec">
     <Holidays>
-      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"
+             localizedType="BANK_HOLIDAY"/>
       <Fixed month="JUNE" day="24" descriptionPropertiesKey="SAINT_JEAN_BAPTISTE_DAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE" localizedType="BANK_HOLIDAY"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
@@ -75,7 +81,8 @@
 
   <SubConfigurations hierarchy="ns" description="Nova Scotia">
     <Holidays>
-      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"
+             localizedType="BANK_HOLIDAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
@@ -85,11 +92,15 @@
         <Date month="MAY" day="25"/>
       </RelativeToFixed>
 
-      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2015" descriptionPropertiesKey="HERITAGE"/>
-      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="NATAL_DAY" localizedType="BANK_HOLIDAY"/>
-      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING" localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2015"
+                    descriptionPropertiesKey="HERITAGE"/>
+      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="NATAL_DAY"
+                    localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"
+                    localizedType="BANK_HOLIDAY"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -104,11 +115,15 @@
         <Date month="MAY" day="25"/>
       </RelativeToFixed>
 
-      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2018" descriptionPropertiesKey="FAMILY_DAY"/>
-      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="NEW_BRUNSWICK_DAY" localizedType="BANK_HOLIDAY"/>
-      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING" localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2018"
+                    descriptionPropertiesKey="FAMILY_DAY"/>
+      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="NEW_BRUNSWICK_DAY"
+                    localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"
+                    localizedType="BANK_HOLIDAY"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -124,11 +139,14 @@
         <Date month="MAY" day="25"/>
       </RelativeToFixed>
 
-      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2008" descriptionPropertiesKey="LOUIS_RIEL"/>
-      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="TERRY_FOX_DAY" localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2008"
+                    descriptionPropertiesKey="LOUIS_RIEL"/>
+      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="TERRY_FOX_DAY"
+                    localizedType="BANK_HOLIDAY"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -148,7 +166,8 @@
       <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="CIVIC"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -169,7 +188,8 @@
       <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="CIVIC"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -185,12 +205,15 @@
         <Date month="MAY" day="25"/>
       </RelativeToFixed>
 
-      <FixedWeekday which="SECOND" weekday="MONDAY" month="FEBRUARY" validFrom="2013" validTo="2018" descriptionPropertiesKey="FAMILY_DAY"/>
-      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2019" descriptionPropertiesKey="FAMILY_DAY"/>
+      <FixedWeekday which="SECOND" weekday="MONDAY" month="FEBRUARY" validFrom="2013" validTo="2018"
+                    descriptionPropertiesKey="FAMILY_DAY"/>
+      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2019"
+                    descriptionPropertiesKey="FAMILY_DAY"/>
       <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="CIVIC"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -206,18 +229,24 @@
         <Date month="MAY" day="25"/>
       </RelativeToFixed>
 
-      <FixedWeekday which="SECOND" weekday="MONDAY" month="FEBRUARY" validFrom="2009" validTo="2009" descriptionPropertiesKey="ISLANDER_DAY"/>
-      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2010" descriptionPropertiesKey="ISLANDER_DAY"/>
-      <FixedWeekday which="THIRD" weekday="FRIDAY" month="AUGUST" descriptionPropertiesKey="GOLD_CUP_PARADE" localizedType="BANK_HOLIDAY"/>
-      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING" localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="SECOND" weekday="MONDAY" month="FEBRUARY" validFrom="2009" validTo="2009"
+                    descriptionPropertiesKey="ISLANDER_DAY"/>
+      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2010"
+                    descriptionPropertiesKey="ISLANDER_DAY"/>
+      <FixedWeekday which="THIRD" weekday="FRIDAY" month="AUGUST" descriptionPropertiesKey="GOLD_CUP_PARADE"
+                    localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"
+                    localizedType="BANK_HOLIDAY"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="sk" description="Saskatchewan">
     <Holidays>
-      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"
+             localizedType="BANK_HOLIDAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
@@ -227,17 +256,20 @@
         <Date month="MAY" day="25"/>
       </RelativeToFixed>
 
-      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2007" descriptionPropertiesKey="FAMILY_DAY"/>
+      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2007"
+                    descriptionPropertiesKey="FAMILY_DAY"/>
       <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="SASKATCHEWAN_DAY"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="ab" description="Alberta">
     <Holidays>
-      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"
+             localizedType="BANK_HOLIDAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
@@ -247,17 +279,21 @@
         <Date month="MAY" day="25"/>
       </RelativeToFixed>
 
-      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="1990" descriptionPropertiesKey="FAMILY_DAY"/>
-      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="HERITAGE" localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="1990"
+                    descriptionPropertiesKey="FAMILY_DAY"/>
+      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="HERITAGE"
+                    localizedType="BANK_HOLIDAY"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="nl" description="Newfoundland and Labrador">
     <Holidays>
-      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"
+             localizedType="BANK_HOLIDAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
@@ -267,9 +303,11 @@
         <Date month="MAY" day="25"/>
       </RelativeToFixed>
 
-      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING" localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"
+                    localizedType="BANK_HOLIDAY"/>
 
-      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"
+                        localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_ca.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_ca.xml
@@ -18,6 +18,8 @@
 
   <SubConfigurations hierarchy="on" description="Ontario">
     <Holidays>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
+      <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE" localizedType="BANK_HOLIDAY"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
 
       <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY">
@@ -27,7 +29,10 @@
       </RelativeToFixed>
 
       <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2008" descriptionPropertiesKey="FAMILY_DAY"/>
+      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="CIVIC" localizedType="BANK_HOLIDAY"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -36,6 +41,7 @@
       <Fixed month="JUNE" day="21" validFrom="2017" descriptionPropertiesKey="INDIGENOUS_PEOPLES_DAY"/>
       <Fixed month="SEPTEMBER" day="30" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
       <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY">
         <Weekday>MONDAY</Weekday>
@@ -45,12 +51,17 @@
 
       <FixedWeekday which="THIRD" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="DISCOVERY_DAY"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="qc" description="Quebec">
     <Holidays>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
       <Fixed month="JUNE" day="24" descriptionPropertiesKey="SAINT_JEAN_BAPTISTE_DAY"/>
+      <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE" localizedType="BANK_HOLIDAY"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
       <RelativeToFixed descriptionPropertiesKey="PATRIOT">
         <Weekday>MONDAY</Weekday>
@@ -66,32 +77,48 @@
 
   <SubConfigurations hierarchy="ns" description="Nova Scotia">
     <Holidays>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
+
+      <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY" localizedType="BANK_HOLIDAY">
+        <Weekday>MONDAY</Weekday>
+        <When>BEFORE</When>
+        <Date month="MAY" day="25"/>
+      </RelativeToFixed>
 
       <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2015" descriptionPropertiesKey="HERITAGE"/>
+      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="NATAL_DAY" localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING" localizedType="BANK_HOLIDAY"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="nb" description="New Brunswick">
     <Holidays>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
-      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="UNOFFICIAL_HOLIDAY"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
-      <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY" localizedType="UNOFFICIAL_HOLIDAY">
+      <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY" localizedType="BANK_HOLIDAY">
         <Weekday>MONDAY</Weekday>
         <When>BEFORE</When>
         <Date month="MAY" day="25"/>
       </RelativeToFixed>
 
       <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2018" descriptionPropertiesKey="FAMILY_DAY"/>
-      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="NEW_BRUNSWICK_DAY"/>
-      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING" localizedType="UNOFFICIAL_HOLIDAY"/>
+      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="NEW_BRUNSWICK_DAY" localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING" localizedType="BANK_HOLIDAY"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="mb" description="Manitoba">
     <Holidays>
       <Fixed month="SEPTEMBER" day="30" validFrom="2024" descriptionPropertiesKey="ORANGE_SHIRT_DAY"/>
+      <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE" localizedType="BANK_HOLIDAY"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
       <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY">
         <Weekday>MONDAY</Weekday>
@@ -100,7 +127,10 @@
       </RelativeToFixed>
 
       <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2008" descriptionPropertiesKey="LOUIS_RIEL"/>
+      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="TERRY_FOX_DAY" localizedType="BANK_HOLIDAY"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -109,6 +139,7 @@
       <Fixed month="JUNE" day="21" validFrom="1996" descriptionPropertiesKey="INDIGENOUS_PEOPLES_DAY"/>
       <Fixed month="SEPTEMBER" day="30" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
       <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY">
         <Weekday>MONDAY</Weekday>
@@ -118,6 +149,8 @@
 
       <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="CIVIC"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -127,6 +160,7 @@
       <Fixed month="JULY" day="9" validFrom="2001" descriptionPropertiesKey="NUNAVUT_DAY"/>
       <Fixed month="SEPTEMBER" day="30" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
       <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY">
         <Weekday>MONDAY</Weekday>
@@ -136,6 +170,8 @@
 
       <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="CIVIC"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -143,6 +179,7 @@
     <Holidays>
       <Fixed month="SEPTEMBER" day="30" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
       <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY">
         <Weekday>MONDAY</Weekday>
@@ -154,6 +191,8 @@
       <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2019" descriptionPropertiesKey="FAMILY_DAY"/>
       <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="CIVIC"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
@@ -161,15 +200,28 @@
     <Holidays>
       <Fixed month="SEPTEMBER" day="30" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
+
+      <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY" localizedType="BANK_HOLIDAY">
+        <Weekday>MONDAY</Weekday>
+        <When>BEFORE</When>
+        <Date month="MAY" day="25"/>
+      </RelativeToFixed>
 
       <FixedWeekday which="SECOND" weekday="MONDAY" month="FEBRUARY" validFrom="2009" validTo="2009" descriptionPropertiesKey="ISLANDER_DAY"/>
       <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2010" descriptionPropertiesKey="ISLANDER_DAY"/>
+      <FixedWeekday which="THIRD" weekday="FRIDAY" month="AUGUST" descriptionPropertiesKey="GOLD_CUP_PARADE" localizedType="BANK_HOLIDAY"/>
+      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING" localizedType="BANK_HOLIDAY"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="sk" description="Saskatchewan">
     <Holidays>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
       <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY">
         <Weekday>MONDAY</Weekday>
@@ -180,12 +232,16 @@
       <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2007" descriptionPropertiesKey="FAMILY_DAY"/>
       <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="SASKATCHEWAN_DAY"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="ab" description="Alberta">
     <Holidays>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
 
       <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY">
         <Weekday>MONDAY</Weekday>
@@ -194,13 +250,28 @@
       </RelativeToFixed>
 
       <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="1990" descriptionPropertiesKey="FAMILY_DAY"/>
+      <FixedWeekday which="FIRST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="HERITAGE" localizedType="BANK_HOLIDAY"/>
       <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="nl" description="Newfoundland and Labrador">
     <Holidays>
+      <Fixed month="SEPTEMBER" day="30" validFrom="2021" descriptionPropertiesKey="TRUTH_RECONCILIATION_DAY" localizedType="BANK_HOLIDAY"/>
       <Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY" localizedType="BANK_HOLIDAY"/>
+
+      <RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY" localizedType="BANK_HOLIDAY">
+        <Weekday>MONDAY</Weekday>
+        <When>BEFORE</When>
+        <Date month="MAY" day="25"/>
+      </RelativeToFixed>
+
+      <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="THANKSGIVING" localizedType="BANK_HOLIDAY"/>
+
+      <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY" localizedType="BANK_HOLIDAY"/>
     </Holidays>
   </SubConfigurations>
 


### PR DESCRIPTION
🎁 closes #606.

Adds missing bank holidays where appropriate. 

Also updates existing holidays with depreciated type "unofficial holiday" to "bank holiday".
