### PR TITLE
Switzerland - Mauritius Day missing in Appenzell Innerrhoden

### DIFF
--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions.properties
@@ -224,6 +224,7 @@ holiday.description.MARTIN_LUTHER_KING                                          
 holiday.description.MARTYRS_DAY                                                         = Martyrs Day
 holiday.description.MARY_PRINCE_DAY                                                     = Mary Prince Day
 holiday.description.MATARIKI                                                            = Matariki
+holiday.description.MAURITIUS_DAY                                                       = Mauritius Day
 holiday.description.MAY_DAY                                                             = May Day
 holiday.description.MAY_DAY_BANK_HOLIDAY                                                = May Day bank holiday
 holiday.description.MAY_REVOLUTION                                                      = May Revolution

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_de.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_de.properties
@@ -223,6 +223,7 @@ holiday.description.MARTIN_LUTHER_KING                                          
 holiday.description.MARTYRS_DAY                                                         = Märtyrer Tag
 holiday.description.MARY_PRINCE_DAY                                                     = Mary Prince Day
 holiday.description.MATARIKI                                                            = Matariki
+holiday.description.MAURITIUS_DAY                                                       = Mauritius Tag
 holiday.description.MAY_DAY                                                             = Mai-Tag
 holiday.description.MAY_DAY_BANK_HOLIDAY                                                = Maifeiertag Bankfeiertag
 holiday.description.MAY_REVOLUTION                                                      = Mai Revolution

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_el.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_el.properties
@@ -224,6 +224,7 @@ holiday.description.MARTIN_LUTHER_KING                                          
 holiday.description.MARTYRS_DAY                                                         = Ημέρα Μαρτύρων
 holiday.description.MARY_PRINCE_DAY                                                     = Ημέρα Mary Prince
 holiday.description.MATARIKI                                                            = Matariki
+holiday.description.MAURITIUS_DAY                                                       = Ημέρα του Μαυρίκιου
 holiday.description.MAY_DAY                                                             = Πρωτομαγιά
 holiday.description.MAY_DAY_BANK_HOLIDAY                                                = Τραπεζική αργία της Πρωτομαγιάς
 holiday.description.MAY_REVOLUTION                                                      = Επανάσταση του Μαΐου

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_fr.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_fr.properties
@@ -224,6 +224,7 @@ holiday.description.MARTIN_LUTHER_KING                                          
 holiday.description.MARTYRS_DAY                                                         = Martyrs Day
 holiday.description.MARY_PRINCE_DAY                                                     = Journée Marie Prince
 holiday.description.MATARIKI                                                            = Matariki
+holiday.description.MAURITIUS_DAY                                                       = Journée de l'île Maurice
 holiday.description.MAY_DAY                                                             = May Day
 holiday.description.MAY_DAY_BANK_HOLIDAY                                                = Jour férié du 1er mai
 holiday.description.MAY_REVOLUTION                                                      = May Revolution

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_nl.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_nl.properties
@@ -224,6 +224,7 @@ holiday.description.MARTIN_LUTHER_KING                                          
 holiday.description.MARTYRS_DAY                                                         = Martelarendag
 holiday.description.MARY_PRINCE_DAY                                                     = Maria Prinsjesdag
 holiday.description.MATARIKI                                                            = Matariki
+holiday.description.MAURITIUS_DAY                                                       = Mauritius-dag
 holiday.description.MAY_DAY                                                             = Mei-dag
 holiday.description.MAY_DAY_BANK_HOLIDAY                                                = Feestdag van mei
 holiday.description.MAY_REVOLUTION                                                      = Mei-revolutie

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_pt.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_pt.properties
@@ -224,6 +224,7 @@ holiday.description.MARTIN_LUTHER_KING                                          
 holiday.description.MARTYRS_DAY                                                         = Dia dos Martires
 holiday.description.MARY_PRINCE_DAY                                                     = Dia de Maria Príncipe
 holiday.description.MATARIKI                                                            = Matariki
+holiday.description.MAURITIUS_DAY                                                       = Dia da Maurícia
 holiday.description.MAY_DAY                                                             = May Day
 holiday.description.MAY_DAY_BANK_HOLIDAY                                                = Feriado bancário do Dia de maio
 holiday.description.MAY_REVOLUTION                                                      = Revolução de Maio

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_sv.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_sv.properties
@@ -224,6 +224,7 @@ holiday.description.MARTIN_LUTHER_KING                                          
 holiday.description.MARTYRS_DAY                                                         = Martyrs Day
 holiday.description.MARY_PRINCE_DAY                                                     = Mary Prince-dagen
 holiday.description.MATARIKI                                                            = Matariki
+holiday.description.MAURITIUS_DAY                                                       = Mauritius-dagen
 holiday.description.MAY_DAY                                                             = May Day
 holiday.description.MAY_DAY_BANK_HOLIDAY                                                = Bankhelg på första maj
 holiday.description.MAY_REVOLUTION                                                      = May Revolution

--- a/jollyday-core/src/main/resources/holidays/Holidays_ch.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_ch.xml
@@ -34,6 +34,7 @@
   <SubConfigurations hierarchy="ai" description="Appenzell Innerrhoden">
     <Holidays>
       <Fixed month="AUGUST" day="15" descriptionPropertiesKey="ASSUMPTION_DAY" localizedType="OBSERVANCE"/>
+      <Fixed month="SEPTEMBER" day="22" descriptionPropertiesKey="MAURITIUS"/>
       <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS" localizedType="OBSERVANCE"/>
       <Fixed month="DECEMBER" day="8" descriptionPropertiesKey="IMMACULATE_CONCEPTION" localizedType="OBSERVANCE"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
@@ -141,6 +142,7 @@
     <Holidays>
       <Fixed month="MARCH" day="19" descriptionPropertiesKey="ST_JOSEPH" localizedType="OBSERVANCE"/>
       <Fixed month="AUGUST" day="15" descriptionPropertiesKey="ASSUMPTION_DAY"/>
+      <Fixed month="SEPTEMBER" day="22" descriptionPropertiesKey="MAURITIUS"/>
       <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
       <Fixed month="DECEMBER" day="8" descriptionPropertiesKey="IMMACULATE_CONCEPTION"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
@@ -208,6 +210,7 @@
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
       <Fixed month="AUGUST" day="15" descriptionPropertiesKey="ASSUMPTION_DAY"/>
+      <Fixed month="SEPTEMBER" day="22" descriptionPropertiesKey="MAURITIUS"/>
       <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
       <Fixed month="DECEMBER" day="8" descriptionPropertiesKey="IMMACULATE_CONCEPTION"/>
       <ChristianHoliday type="GOOD_FRIDAY" descriptionPropertiesKey="christian.GOOD_FRIDAY"/>

--- a/jollyday-core/src/main/resources/holidays/Holidays_ch.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_ch.xml
@@ -34,7 +34,7 @@
   <SubConfigurations hierarchy="ai" description="Appenzell Innerrhoden">
     <Holidays>
       <Fixed month="AUGUST" day="15" descriptionPropertiesKey="ASSUMPTION_DAY" localizedType="OBSERVANCE"/>
-      <Fixed month="SEPTEMBER" day="22" descriptionPropertiesKey="MAURITIUS"/>
+      <Fixed month="SEPTEMBER" day="22" descriptionPropertiesKey="MAURITIUS_DAY"/>
       <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS" localizedType="OBSERVANCE"/>
       <Fixed month="DECEMBER" day="8" descriptionPropertiesKey="IMMACULATE_CONCEPTION" localizedType="OBSERVANCE"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
@@ -142,7 +142,6 @@
     <Holidays>
       <Fixed month="MARCH" day="19" descriptionPropertiesKey="ST_JOSEPH" localizedType="OBSERVANCE"/>
       <Fixed month="AUGUST" day="15" descriptionPropertiesKey="ASSUMPTION_DAY"/>
-      <Fixed month="SEPTEMBER" day="22" descriptionPropertiesKey="MAURITIUS"/>
       <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
       <Fixed month="DECEMBER" day="8" descriptionPropertiesKey="IMMACULATE_CONCEPTION"/>
       <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
@@ -210,7 +209,6 @@
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
       <Fixed month="AUGUST" day="15" descriptionPropertiesKey="ASSUMPTION_DAY"/>
-      <Fixed month="SEPTEMBER" day="22" descriptionPropertiesKey="MAURITIUS"/>
       <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
       <Fixed month="DECEMBER" day="8" descriptionPropertiesKey="IMMACULATE_CONCEPTION"/>
       <ChristianHoliday type="GOOD_FRIDAY" descriptionPropertiesKey="christian.GOOD_FRIDAY"/>


### PR DESCRIPTION
"Mauritiustag" is missing
Proof: https://www.ferienwiki.ch/feiertage/2024/ch

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
