### PR TITLE
Improve jollyday-jackson OSGi bundle compatiblity

### DIFF
--- a/jollyday-jackson/pom.xml
+++ b/jollyday-jackson/pom.xml
@@ -72,6 +72,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>de.focus_shift.jollyday-jackson</Bundle-SymbolicName>
+            <Import-Package>com.fasterxml.jackson.*;version="[2.17,3)",*</Import-Package>
             <Export-Package>de.focus_shift.jollyday.jackson.*</Export-Package>
             <Require-Capability>osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
             <Provide-Capability>osgi.serviceloader;osgi.serviceloader=de.focus_shift.jollyday.core.spi.ConfigurationService</Provide-Capability>


### PR DESCRIPTION
It still works fine with Jackson 2.17 so there is no need to require Jackson 2.18+. Requiring Jackson 2.18 in OSGi applications having other dependencies is a headache because this version uses Woodstox 7. Woodstox 7 is not yet supported in bundle version ranges of any CXF or Aries JAX RS Whiteboard release.

Related to https://github.com/focus-shift/jollyday/pull/626