### PR TITLE
Remove deprecated 'getHolidays(int year, ...)' method

### DIFF
--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/HolidayManager.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/HolidayManager.java
@@ -260,33 +260,8 @@ public abstract class HolidayManager {
    * @param year i.e. 2010
    * @param args i.e. args = {'ny'}. returns US/New York holidays. No args means holidays common to whole country
    * @return a set of holidays for the requested year
-   *
-   * @deprecated in favor of <code>getHolidays(final Year year, final String... args)</code>
-   */
-  @Deprecated(forRemoval = true, since = "0.31.0")
-  public abstract Set<Holiday> getHolidays(final int year, final String... args);
-
-  /**
-   * Returns the holidays for the requested year and hierarchy structure.
-   *
-   * @param year i.e. 2010
-   * @param args i.e. args = {'ny'}. returns US/New York holidays. No args means holidays common to whole country
-   * @return a set of holidays for the requested year
    */
   public abstract Set<Holiday> getHolidays(final Year year, final String... args);
-
-  /**
-   * Returns the holidays for the requested year, the given {@link HolidayType} and the hierarchy structure
-   *
-   * @param year        i.e. 2010
-   * @param holidayType a {@link HolidayType} to be considered
-   * @param args        i.e. args = {'ny'}. returns US/New York holidays. No args means holidays common to whole country
-   * @return a set of holidays of the given {@link HolidayType} for the requested year
-   *
-   * @deprecated in favor of <code>getHolidays(final Year year, final HolidayType holidayType, final String... args);</code>
-   */
-  @Deprecated(forRemoval = true, since = "0.31.0")
-  public abstract Set<Holiday> getHolidays(final int year, final HolidayType holidayType, final String... args);
 
   /**
    * Returns the holidays for the requested year, the given {@link HolidayType} and the hierarchy structure

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/DefaultHolidayManager.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/DefaultHolidayManager.java
@@ -88,18 +88,6 @@ public class DefaultHolidayManager extends HolidayManager {
    * with the configuration from initialization.
    */
   @Override
-  public Set<Holiday> getHolidays(final int year, final String... args) {
-    return getHolidays(Year.of(year), args);
-  }
-
-  /**
-   * {@inheritDoc}
-   * <p>
-   * Calls
-   * <code>Set&lt;LocalDate&gt; getHolidays(Year year, Configuration c, String... args)</code>
-   * with the configuration from initialization.
-   */
-  @Override
   public Set<Holiday> getHolidays(final Year year, final String... args) {
 
     final StringBuilder keyBuilder = new StringBuilder();
@@ -130,14 +118,6 @@ public class DefaultHolidayManager extends HolidayManager {
    * {@inheritDoc}
    */
   @Override
-  public Set<Holiday> getHolidays(final int year, final HolidayType holidayType, final String... args) {
-    return getHolidays(Year.of(year), holidayType, args);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
   public Set<Holiday> getHolidays(final Year year, final HolidayType holidayType, final String... args) {
     return getHolidays(year, args).stream()
       .filter(holiday -> holiday.getType().equals(holidayType))
@@ -157,7 +137,8 @@ public class DefaultHolidayManager extends HolidayManager {
     Objects.requireNonNull(endDateInclusive, "endDateInclusive is null");
 
     return rangeClosed(startDateInclusive.getYear(), endDateInclusive.getYear())
-      .mapToObj(year -> getHolidays(year, args))
+      .mapToObj(Year::of)
+      .map(year -> getHolidays(year, args))
       .flatMap(Collection::stream)
       .filter(holiday -> !startDateInclusive.isAfter(holiday.getDate()) && !endDateInclusive.isBefore(holiday.getDate()))
       .collect(toUnmodifiableSet());

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/JapaneseHolidayManager.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/JapaneseHolidayManager.java
@@ -26,20 +26,6 @@ public class JapaneseHolidayManager extends DefaultHolidayManager {
    * <p>
    * Implements the rule which requests if two holidays have one non holiday
    * between each other than this day is also a holiday.
-   *
-   * @deprecated in favor of <code>getHolidays(final Year year, final String... args)</code>
-   */
-  @Deprecated(forRemoval = true, since = "0.31.0")
-  @Override
-  public Set<Holiday> getHolidays(final int year, final String... args) {
-    return getHolidays(Year.of(year), args);
-  }
-
-  /**
-   * {@inheritDoc}
-   * <p>
-   * Implements the rule which requests if two holidays have one non holiday
-   * between each other than this day is also a holiday.
    */
   @Override
   public Set<Holiday> getHolidays(final Year year, final String... args) {


### PR DESCRIPTION
closes #682

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
