### PR TITLE
Add missing federal Columbus Day holiday to US calendar

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_us.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_us.xml
@@ -30,6 +30,7 @@
     <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="1971" descriptionPropertiesKey="PRESIDENTS_DAY"/>
     <FixedWeekday which="LAST" weekday="MONDAY" month="MAY" validFrom="1968" descriptionPropertiesKey="MEMORIAL_DAY"/>
     <FixedWeekday which="FIRST" weekday="MONDAY" month="SEPTEMBER" validFrom="1895" descriptionPropertiesKey="LABOUR_DAY"/>
+    <FixedWeekday which="SECOND" weekday="MONDAY" month="OCTOBER" validFrom="1971" descriptionPropertiesKey="COLUMBUS_DAY"/>
     <FixedWeekday which="FOURTH" weekday="THURSDAY" month="NOVEMBER" validFrom="1863" descriptionPropertiesKey="THANKSGIVING"/>
   </Holidays>
 


### PR DESCRIPTION
## Summary

- Columbus Day (2nd Monday of October) is one of the 11 US federal holidays but was missing from the federal-level `<Holidays>` section in `Holidays_us.xml`
- It was only defined at the state level for individual states, meaning querying for `us` (federal) holidays omitted it
- Uses `validFrom="1971"` to reflect when the [Uniform Monday Holiday Act](https://en.wikipedia.org/wiki/Uniform_Monday_Holiday_Act) moved it to the second Monday of October

## References

- [OPM Federal Holidays](https://www.opm.gov/policy-data-oversight/pay-leave/federal-holidays/) — official list of 11 federal holidays
- [5 U.S.C. § 6103](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title5-section6103) — the statute designating federal holidays
- [Wikipedia: Columbus Day](https://en.wikipedia.org/wiki/Columbus_Day)
- [Wikipedia: Federal holidays in the United States](https://en.wikipedia.org/wiki/Federal_holidays_in_the_United_States)

## Test plan

- [x] Existing `HolidayUSTest` passes
- [ ] Verify Columbus Day appears when querying federal US holidays for years >= 1971

🤖 Generated with [Claude Code](https://claude.com/claude-code)