### PR TITLE
Fix Moselle public holidays (Good Friday condition + Dec 26)

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_fr.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_fr.xml
@@ -163,7 +163,8 @@
   </SubConfigurations>
   <SubConfigurations hierarchy="57" description="Moselle">
     <Holidays>
-      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="ABOLITION_OF_SLAVERY"/>
+      <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="SECOND_CHRISTMAS_DAY"/>
+      <ChristianHoliday type="GOOD_FRIDAY"/>
     </Holidays>
   </SubConfigurations>
   <SubConfigurations hierarchy="88" description="Vosges">

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayFRTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayFRTest.java
@@ -34,7 +34,10 @@ class HolidayFRTest {
         .validFrom(Year.of(2008))
       .and()
 
-      .hasFixedHoliday("ABOLITION_OF_SLAVERY", DECEMBER, 26)
+      .hasFixedHoliday("SECOND_CHRISTMAS_DAY", DECEMBER, 26)
+        .inSubdivision("57")
+      .and()
+      .hasChristianHoliday("GOOD_FRIDAY")
         .inSubdivision("57")
       .and()
 


### PR DESCRIPTION
This PR fixes the France holiday configuration for the **Moselle local law**.

### Broken behavior

The current configuration does not correctly reflect the additional public holidays applicable in Moselle under local law:

* **Good Friday** (with the legal condition: only in communes with a Protestant temple or a mixed church)
* **December 26th** (Saint-Étienne / second day of Christmas)

### Legal source

See the French Labor Code (local law) — **Article L3134-13**:
[https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006902635](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006902635)

P.S.: I don't know how to put label or status here, sorry in advance.

closes #939