### PR TITLE
au: fix Anzac Day moving conditions for NSW and SA

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_au.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_au.xml
@@ -86,6 +86,10 @@
       <Fixed month="APRIL" day="25" validTo="2007" descriptionPropertiesKey="ANZAC">
         <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
       </Fixed>
+      <Fixed month="APRIL" day="25" validFrom="2026" descriptionPropertiesKey="ANZAC">
+        <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
+        <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
+      </Fixed>
       <Fixed month="DECEMBER" day="25" validFrom="2008" validTo="2019" descriptionPropertiesKey="CHRISTMAS">
         <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
         <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
@@ -171,7 +175,7 @@
       <Fixed month="APRIL" day="25" validTo="2007" descriptionPropertiesKey="ANZAC">
         <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
       </Fixed>
-      <Fixed month="APRIL" day="25" validFrom="2020" descriptionPropertiesKey="ANZAC">
+      <Fixed month="APRIL" day="25" validFrom="2020" validTo="2022" descriptionPropertiesKey="ANZAC">
         <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
       </Fixed>
       <Fixed month="DECEMBER" day="25" validFrom="2008" validTo="2019" descriptionPropertiesKey="CHRISTMAS">

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayAUTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayAUTest.java
@@ -1,14 +1,19 @@
 package de.focus_shift.jollyday.tests.country;
 
-import de.focus_shift.jollyday.core.CalendarHierarchy;
+import de.focus_shift.jollyday.core.Holiday;
 import de.focus_shift.jollyday.core.HolidayManager;
-import de.focus_shift.jollyday.core.ManagerParameters;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.time.api.constraints.YearRange;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.time.Year;
+import java.util.Set;
+
+import static de.focus_shift.jollyday.core.HolidayCalendar.AUSTRALIA;
+import static de.focus_shift.jollyday.core.ManagerParameters.create;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class HolidayAUTest extends AbstractCountryTestBase {
 
@@ -21,15 +26,85 @@ class HolidayAUTest extends AbstractCountryTestBase {
 
   @Test
   void testManagerAULoadFromUrl() {
-    final HolidayManager calendarPartLoaded = HolidayManager.getInstance(ManagerParameters.create("test_au_2020"));
+    final HolidayManager calendarPartLoaded = HolidayManager.getInstance(create("test_au_2020"));
     final HolidayManager urlLoaded = HolidayManager.getInstance(
-      ManagerParameters.create(AbstractCountryTestBase.class.getClassLoader().getResource("holidays/Holidays_test_au_2020.xml"))
+      create(AbstractCountryTestBase.class.getClassLoader().getResource("holidays/Holidays_test_au_2020.xml"))
     );
 
-    final CalendarHierarchy dataHierarchy = calendarPartLoaded.getCalendarHierarchy();
-    final CalendarHierarchy testHierarchy = urlLoaded.getCalendarHierarchy();
+    final var dataHierarchy = calendarPartLoaded.getCalendarHierarchy();
+    final var testHierarchy = urlLoaded.getCalendarHierarchy();
 
     compareHierarchies(testHierarchy, dataHierarchy);
     compareData(urlLoaded, calendarPartLoaded, Year.of(2020), true);
+  }
+
+  @Test
+  void ensuresNswAnzacDaySubstituteWhenSaturdayFrom2026() {
+    // Anzac Day 2026 falls on Saturday — NSW should get Monday substitute from 2026
+    final HolidayManager manager = HolidayManager.getInstance(create(AUSTRALIA));
+
+    final Set<Holiday> nswHolidays2026 = manager.getHolidays(Year.of(2026), "nsw");
+    assertThat(nswHolidays2026)
+      .extracting(Holiday::getDate)
+      .contains(LocalDate.of(2026, 4, 25))  // Anzac Day itself
+      .contains(LocalDate.of(2026, 4, 27)); // Monday substitute
+  }
+
+  @Test
+  void ensuresNswAnzacDayNoSubstituteBefore2026() {
+    // Anzac Day 2025 falls on Friday — no substitute needed, but also confirm
+    // that the validFrom=2026 boundary is respected by checking a year where
+    // Anzac Day falls on Sunday (2021) — NSW should NOT get a Monday substitute before 2026
+    final HolidayManager manager = HolidayManager.getInstance(create(AUSTRALIA));
+
+    final Set<Holiday> nswHolidays2021 = manager.getHolidays(Year.of(2021), "nsw");
+    assertThat(nswHolidays2021)
+      .extracting(Holiday::getDate)
+      .contains(LocalDate.of(2021, 4, 25))     // Anzac Day itself (Sunday)
+      .doesNotContain(LocalDate.of(2021, 4, 26)); // No Monday substitute before 2026
+  }
+
+  @Test
+  void ensuresSaAnzacDayNoSubstitute() {
+    // SA does not provide a substitute holiday when Anzac Day falls on a weekend
+    final HolidayManager manager = HolidayManager.getInstance(create(AUSTRALIA));
+
+    // 2026: Anzac Day on Saturday
+    final Set<Holiday> saHolidays2026 = manager.getHolidays(Year.of(2026), "sa");
+    assertThat(saHolidays2026)
+      .extracting(Holiday::getDate)
+      .contains(LocalDate.of(2026, 4, 25))     // Anzac Day itself
+      .doesNotContain(LocalDate.of(2026, 4, 27)); // No Monday substitute
+
+    // 2027: Anzac Day on Sunday
+    final Set<Holiday> saHolidays2027 = manager.getHolidays(Year.of(2027), "sa");
+    assertThat(saHolidays2027)
+      .extracting(Holiday::getDate)
+      .contains(LocalDate.of(2027, 4, 25))     // Anzac Day itself
+      .doesNotContain(LocalDate.of(2027, 4, 26)); // No Monday substitute
+  }
+
+  @Test
+  void ensuresNswAnzacDaySubstituteWhenSundayFrom2026() {
+    // Anzac Day 2027 falls on Sunday — NSW should get Monday substitute
+    final HolidayManager manager = HolidayManager.getInstance(create(AUSTRALIA));
+
+    final Set<Holiday> nswHolidays2027 = manager.getHolidays(Year.of(2027), "nsw");
+    assertThat(nswHolidays2027)
+      .extracting(Holiday::getDate)
+      .contains(LocalDate.of(2027, 4, 25))  // Anzac Day itself
+      .contains(LocalDate.of(2027, 4, 26)); // Monday substitute
+  }
+
+  @Test
+  void ensuresActAnzacDaySubstituteStillWorks() {
+    // ACT has long-standing Sat/Sun substitution — regression check
+    final HolidayManager manager = HolidayManager.getInstance(create(AUSTRALIA));
+
+    final Set<Holiday> actHolidays2026 = manager.getHolidays(Year.of(2026), "act");
+    assertThat(actHolidays2026)
+      .extracting(Holiday::getDate)
+      .contains(LocalDate.of(2026, 4, 25))  // Anzac Day itself
+      .contains(LocalDate.of(2026, 4, 27)); // Monday substitute
   }
 }


### PR DESCRIPTION
## Summary

- **NSW**: Add Saturday→Monday and Sunday→Monday substitute for Anzac Day from 2026, per the [NSW Public Holidays page](https://www.nsw.gov.au/about-nsw/public-holidays) and the [Public Holidays Act 2010 (NSW)](https://legislation.nsw.gov.au/view/html/inforce/current/act-2010-115)
- **SA**: Cap Sunday→Monday substitute at 2022. The [Public Holidays Act 2023 (SA)](https://www.legislation.sa.gov.au/_legislation-documents/lz/c/a/public-holidays-act-2023/current/2023.39.auth.pdf) removed Anzac Day weekend substitution from 2023 onward

### Context

Anzac Day 2026 (April 25) falls on a Saturday. NSW now provides an additional public holiday on Monday April 27. SA confirmed they will not follow suit.

| State | Sat sub | Sun sub | Status |
|-------|---------|---------|--------|
| NSW | Yes (from 2026) | Yes (from 2026) | **Fixed in this PR** |
| SA | No (from 2023) | No (from 2023) | **Fixed in this PR** |
| ACT | Yes | Yes | Already correct |
| WA | Yes | Yes | Already correct |

## Test plan

- Added targeted tests for NSW Anzac Day substitute on Saturday (2026) and Sunday (2027)
- Added boundary test confirming NSW has no substitute before 2026
- Added test confirming SA has no substitute for Saturday (2026) or Sunday (2027)
- Added ACT regression test
- Existing `validateCalendarData` property test (2019–2022) continues to pass