### PR TITLE
Fix for Potential input resource leak in test

### DIFF
--- a/jollyday-core/src/test/java/de/focus_shift/jollyday/core/HolidayDescriptionTest.java
+++ b/jollyday-core/src/test/java/de/focus_shift/jollyday/core/HolidayDescriptionTest.java
@@ -48,7 +48,9 @@ class HolidayDescriptionTest {
     final Set<String> propertiesNames = new HashSet<>();
     for (final File descriptionFile : descriptions) {
       final Properties props = new Properties();
-      props.load(new FileInputStream(descriptionFile));
+      try (FileInputStream inputStream = new FileInputStream(descriptionFile)) {
+        props.load(inputStream);
+      }
       propertiesNames.addAll(props.stringPropertyNames());
     }
     return propertiesNames;


### PR DESCRIPTION
Use try-with-resources around the `FileInputStream` in `getLocalisedResourceBundleKeys()`, so each stream is closed immediately after `Properties.load(...)` completes (including on exceptions).  
Best minimal fix: replace the single `props.load(new FileInputStream(descriptionFile));` line with a `try (FileInputStream inputStream = new FileInputStream(descriptionFile)) { props.load(inputStream); }`. This preserves existing behavior while guaranteeing proper cleanup. No new imports are required because `FileInputStream` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._