### PR TITLE
Fix for Missing Override annotation

### DIFF
--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/parameter/BaseManagerParameter.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/parameter/BaseManagerParameter.java
@@ -27,6 +27,7 @@ public abstract class BaseManagerParameter implements ManagerParameter {
     }
   }
 
+  @Override
   public @NonNull Optional<String> getProperty(@NonNull String key) {
     return Optional.ofNullable(properties.getProperty(key));
   }


### PR DESCRIPTION
Add the missing `@Override` annotation directly above `getProperty` in:

- `jollyday-core/src/main/java/de/focus_shift/jollyday/core/parameter/BaseManagerParameter.java` (around line 30)

This is the best fix because it preserves behavior entirely, aligns with existing class conventions, and enables compiler checks for interface conformance. No method signature or logic changes are needed, and no imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._