### PR TITLE
Fix for Exposing internal representation

### DIFF
--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/CalendarHierarchy.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/CalendarHierarchy.java
@@ -3,6 +3,7 @@ package de.focus_shift.jollyday.core;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -101,7 +102,7 @@ public class CalendarHierarchy {
    * @param children the children to set
    */
   public void setChildren(final Map<String, CalendarHierarchy> children) {
-    this.children = children;
+    this.children = new HashMap<>(children);
   }
 
   /**
@@ -112,7 +113,7 @@ public class CalendarHierarchy {
    * @return the children
    */
   public @NonNull Map<String, CalendarHierarchy> getChildren() {
-    return children;
+    return Collections.unmodifiableMap(new HashMap<>(children));
   }
 
   /**


### PR DESCRIPTION
Use **defensive copying** and return an **unmodifiable view/copy** from the getter.

Best fix without changing intended functionality:
- In `setChildren(...)`, copy incoming map into a new `HashMap` instead of storing the passed reference.
- In `getChildren()`, return an unmodifiable map (preferably an unmodifiable copy) so callers cannot mutate internal state.
- Add needed import for `Collections`.

Edits are all in:
- `jollyday-core/src/main/java/de/focus_shift/jollyday/core/CalendarHierarchy.java`
  - imports section
  - `setChildren(...)`
  - `getChildren()`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._