### PR TITLE
Optimize mergeProperties to Avoid Unnecessary Properties Object Creation

### DIFF
--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/parameter/BaseManagerParameter.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/parameter/BaseManagerParameter.java
@@ -50,7 +50,7 @@ public abstract class BaseManagerParameter implements ManagerParameter {
   public @NonNull String getParserImplClassName(@NonNull final String className) {
     final Optional<String> parserImplClass = getProperty(PARSER_IMPL_PREFIX + className);
     if (parserImplClass.isEmpty()) {
-      throw new IllegalStateException("Cannot create parsers. No parser implementation defined for class " + className + " in properties with key " + PARSER_IMPL_PREFIX + className);
+      throw new IllegalStateException("Cannot create parsers. No parser implementation defined for key: " + PARSER_IMPL_PREFIX + className);
     }
     return parserImplClass.get();
   }

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/parameter/BaseManagerParameter.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/parameter/BaseManagerParameter.java
@@ -20,10 +20,11 @@ public abstract class BaseManagerParameter implements ManagerParameter {
   @Override
   public void mergeProperties(@Nullable final Properties properties) {
     if (properties != null) {
-      final Properties mergedProperties = new Properties();
-      mergedProperties.putAll(properties);
-      mergedProperties.putAll(this.properties);
-      this.properties = mergedProperties;
+      final Properties currentProperties = new Properties();
+      currentProperties.putAll(this.properties);
+      this.properties.clear();
+      this.properties.putAll(properties);
+      this.properties.putAll(currentProperties);
     }
   }
 


### PR DESCRIPTION
The mergeProperties method creates a new Properties object and performs two putAll operations, which is inefficient. Consider directly modifying this.properties by calling this.properties.putAll(properties) after putting the incoming properties first, or simply reversing the order of putAll calls to avoid creating an unnecessary intermediate object.