### PR TITLE
fix: return English descriptions for Locale.ENGLISH regardless of def…

### DIFF
--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/ResourceUtil.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/util/ResourceUtil.java
@@ -14,8 +14,6 @@ import java.util.ResourceBundle;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
-import static java.util.ResourceBundle.getBundle;
-
 public final class ResourceUtil {
 
   private ResourceUtil() {
@@ -40,7 +38,7 @@ public final class ResourceUtil {
    */
   private static final String HOLIDAY_PROPERTY_PREFIX = "holiday.description";
   /**
-   * The prefix of the holiday descriptions file.
+   * The prefix of the holiday description file.
    */
   private static final String HOLIDAY_DESCRIPTIONS_FILE_PREFIX = "descriptions.holiday_descriptions";
   /**
@@ -141,11 +139,34 @@ public final class ResourceUtil {
   /**
    * Returns the eventually cached ResourceBundle for the descriptions.
    *
-   * @param locale Locale to retrieve the descriptions for.
+   * @param locale        Locale to retrieve the descriptions for.
+   * @param resourceCache the cache to use
+   * @param filePrefix    the resource bundle name prefix (without locale suffix)
    * @return ResourceBundle containing the descriptions for the locale.
    */
-  private static @NonNull ResourceBundle getResourceBundle(@NonNull final Locale locale, @NonNull final Map<Locale, ResourceBundle> resourceCache, @NonNull final String filePrefix) {
-    return resourceCache.computeIfAbsent(locale, givenLocale -> getBundle(filePrefix, givenLocale, ClassLoadingUtil.getClassloader()));
+  private static @NonNull ResourceBundle getResourceBundle(
+    @NonNull final Locale locale,
+    @NonNull final Map<Locale, ResourceBundle> resourceCache,
+    @NonNull final String filePrefix
+  ) {
+    return resourceCache.computeIfAbsent(locale, givenLocale -> {
+      final ResourceBundle bundle = ResourceBundle.getBundle(filePrefix, givenLocale, ClassLoadingUtil.getClassloader());
+
+      // ResourceBundle.getBundle(baseName, locale) consults Locale.getDefault() whenever the
+      // requested locale itself has no dedicated resource file - even though a root/base bundle
+      // further down the candidate chain would otherwise satisfy the request. In other words,
+      // requesting e.g. Locale.ENGLISH or Locale.ITALIAN (neither has a dedicated properties file
+      // here) on a JVM whose default locale happens to be one we DO ship a translation for
+      // (de, el, fr, nl, pt, sv) silently returns that translation instead of the base (English)
+      // bundle. A resolved bundle whose locale doesn't match the requested locale's language - and
+      // isn't the root locale itself - is exactly this misfire. Requesting Locale.ROOT directly is
+      // never subject to this default-locale fallback, so re-querying with it recovers the
+      // intended base bundle without mutating any shared/global state.
+      if (!Locale.ROOT.equals(bundle.getLocale()) && !bundle.getLocale().getLanguage().equals(givenLocale.getLanguage())) {
+        return ResourceBundle.getBundle(filePrefix, Locale.ROOT, ClassLoadingUtil.getClassloader());
+      }
+      return bundle;
+    });
   }
 
   /**

--- a/jollyday-core/src/test/java/de/focus_shift/jollyday/core/util/ResourceUtilTest.java
+++ b/jollyday-core/src/test/java/de/focus_shift/jollyday/core/util/ResourceUtilTest.java
@@ -1,0 +1,393 @@
+package de.focus_shift.jollyday.core.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResourceUtilTest {
+
+  private Locale originalDefaultLocale;
+
+  @BeforeEach
+  void setUp() {
+    originalDefaultLocale = Locale.getDefault();
+  }
+
+  @AfterEach
+  void tearDown() {
+    Locale.setDefault(originalDefaultLocale);
+    clearCaches();
+  }
+
+  @Test
+  void ensureEnglishCountryDescriptionIsReturnedWithGermanDefaultLocale() {
+    // Clear caches to ensure fresh bundle loading
+    clearCaches();
+
+    // Set default locale to German - this is the scenario that caused the bug
+    Locale.setDefault(Locale.GERMANY);
+
+    // Request English description for Germany
+    final String description = ResourceUtil.getCountryDescription(Locale.ENGLISH, "de");
+
+    // Should return English "Germany", not German "Deutschland"
+    assertThat(description)
+      .as("Country description for 'de' with Locale.ENGLISH should be in English even when default locale is German")
+      .isEqualTo("Germany");
+  }
+
+  @Test
+  void ensureEnglishHolidayDescriptionIsReturnedWithGermanDefaultLocale() {
+    // Clear caches to ensure fresh bundle loading
+    clearCaches();
+
+    // Set default locale to German
+    Locale.setDefault(Locale.GERMANY);
+
+    // Request English holiday description for New Year
+    final String description = ResourceUtil.getHolidayDescription(Locale.ENGLISH, "NEW_YEAR");
+
+    // Should return English "New Year's Day", not German "Neujahr"
+    assertThat(description)
+      .as("Holiday description for 'NEW_YEAR' with Locale.ENGLISH should be in English even when default locale is German")
+      .isEqualTo("New Year's Day");
+  }
+
+  @Test
+  void ensureGermanCountryDescriptionIsReturnedWithGermanDefaultLocale() {
+    // Clear caches to ensure fresh bundle loading
+    clearCaches();
+
+    // Set default locale to German
+    Locale.setDefault(Locale.GERMANY);
+
+    // Request German description for Germany
+    final String description = ResourceUtil.getCountryDescription(Locale.GERMANY, "de");
+
+    // Should return German "Deutschland"
+    assertThat(description)
+      .as("Country description for 'de' with Locale.GERMANY should be in German")
+      .isEqualTo("Deutschland");
+  }
+
+  @Test
+  void ensureGermanHolidayDescriptionIsReturnedWithGermanDefaultLocale() {
+    // Clear caches to ensure fresh bundle loading
+    clearCaches();
+
+    // Set default locale to German
+    Locale.setDefault(Locale.GERMANY);
+
+    // Request German holiday description for New Year
+    final String description = ResourceUtil.getHolidayDescription(Locale.GERMANY, "NEW_YEAR");
+
+    // Should return German "Neujahr"
+    assertThat(description)
+      .as("Holiday description for 'NEW_YEAR' with Locale.GERMANY should be in German")
+      .isEqualTo("Neujahr");
+  }
+
+  @Test
+  void ensureEnglishCountryDescriptionIsReturnedWithFrenchDefaultLocale() {
+    // Clear caches to ensure fresh bundle loading
+    clearCaches();
+
+    // Set default locale to French
+    Locale.setDefault(Locale.FRANCE);
+
+    // Request English description for France
+    final String description = ResourceUtil.getCountryDescription(Locale.ENGLISH, "fr");
+
+    // Should return English "France", not French "France" (same in this case, but let's use a different one)
+    // Let's use "de" to get "Germany" vs "Allemagne"
+    final String germanyDescription = ResourceUtil.getCountryDescription(Locale.ENGLISH, "de");
+    assertThat(germanyDescription)
+      .as("Country description for 'de' with Locale.ENGLISH should be in English even when default locale is French")
+      .isEqualTo("Germany");
+  }
+
+  @Test
+  void ensureUndefinedIsReturnedForNonexistentKey() {
+    // Clear caches to ensure fresh bundle loading
+    clearCaches();
+
+    Locale.setDefault(Locale.GERMANY);
+
+    final String countryDescription = ResourceUtil.getCountryDescription(Locale.ENGLISH, "zz");
+    assertThat(countryDescription)
+      .isEqualTo(ResourceUtil.UNDEFINED);
+
+    final String holidayDescription = ResourceUtil.getHolidayDescription(Locale.ENGLISH, "NONEXISTENT_HOLIDAY");
+    assertThat(holidayDescription)
+      .isEqualTo(ResourceUtil.UNDEFINED);
+  }
+
+  @Test
+  void ensureUndefinedIsReturnedForNullCountryKey() {
+    final String description = ResourceUtil.getCountryDescription(Locale.ENGLISH, null);
+    assertThat(description)
+      .isEqualTo(ResourceUtil.UNDEFINED);
+  }
+
+  @Test
+  void ensureEnglishDescriptionWithUsDefaultLocale() {
+    // Clear caches to ensure fresh bundle loading
+    clearCaches();
+
+    // Set default locale to US
+    Locale.setDefault(Locale.US);
+
+    // Request English description - should still work
+    final String description = ResourceUtil.getCountryDescription(Locale.ENGLISH, "de");
+    assertThat(description)
+      .isEqualTo("Germany");
+  }
+
+  @Test
+  void getCountryDescriptionWithDefaultLocaleReturnsDescriptionForDefaultLocale() {
+    clearCaches();
+
+    Locale.setDefault(Locale.GERMANY);
+    final String description = ResourceUtil.getCountryDescription("de");
+    assertThat(description)
+      .as("getCountryDescription(String) with German default locale should return German description")
+      .isEqualTo("Deutschland");
+
+    clearCaches();
+    Locale.setDefault(Locale.ENGLISH);
+    final String descriptionAfterReset = ResourceUtil.getCountryDescription("de");
+    assertThat(descriptionAfterReset)
+      .as("getCountryDescription(String) with English default locale should return English description")
+      .isEqualTo("Germany");
+  }
+
+  @Test
+  void getHolidayDescriptionWithDefaultLocaleReturnsDescriptionForDefaultLocale() {
+    clearCaches();
+
+    Locale.setDefault(Locale.GERMANY);
+    final String description = ResourceUtil.getHolidayDescription("NEW_YEAR");
+    assertThat(description)
+      .as("getHolidayDescription(String) with German default locale should return German description")
+      .isEqualTo("Neujahr");
+
+    clearCaches();
+    Locale.setDefault(Locale.ENGLISH);
+    final String descriptionAfterReset = ResourceUtil.getHolidayDescription("NEW_YEAR");
+    assertThat(descriptionAfterReset)
+      .as("getHolidayDescription(String) with English default locale should return English description")
+      .isEqualTo("New Year's Day");
+  }
+
+  @Test
+  void getResourceReturnsOptionalPresentForExistingResource() {
+    final var resource = ResourceUtil.getResource("jollyday.properties");
+    assertThat(resource)
+      .as("getResource should return a present Optional for existing resource")
+      .isPresent();
+    assertThat(resource.get().getFile())
+      .endsWith("jollyday.properties");
+  }
+
+  @Test
+  void getResourceReturnsOptionalEmptyForNonexistentResource() {
+    final var resource = ResourceUtil.getResource("this_file_does_not_exist_12345.properties");
+    assertThat(resource)
+      .as("getResource should return an empty Optional for nonexistent resource")
+      .isEmpty();
+  }
+
+  @Test
+  void getResourceWithSearchOnlyInJarReturnsEmptyForClasspathResource() {
+    // jollyday.properties is on the classpath, not in a JAR
+    final var resource = ResourceUtil.getResource("jollyday.properties", true);
+    assertThat(resource)
+      .as("getResource with searchOnlyInJar=true should return empty for classpath resource")
+      .isEmpty();
+  }
+
+  @Test
+  void getResourceWithSearchOnlyInJarReturnsEmptyForNonexistentResource() {
+    final var resource = ResourceUtil.getResource("nonexistent.properties", true);
+    assertThat(resource)
+      .as("getResource with searchOnlyInJar=true should return empty for nonexistent resource")
+      .isEmpty();
+  }
+
+  @Test
+  void undefinedConstantHasExpectedValue() {
+    assertThat(ResourceUtil.UNDEFINED)
+      .isEqualTo("undefined");
+  }
+
+  @Test
+  void getCountryDescriptionUsesDefaultLocaleWhenNoLocaleProvided() {
+    clearCaches();
+
+    // With French default locale, calling the single-arg overload should return French text
+    Locale.setDefault(Locale.FRANCE);
+    final String description = ResourceUtil.getCountryDescription("de");
+    assertThat(description)
+      .as("getCountryDescription(String) with French default locale should return French description")
+      .isEqualTo("Allemagne");
+  }
+
+  @Test
+  void getHolidayDescriptionUsesDefaultLocaleWhenNoLocaleProvided() {
+    clearCaches();
+
+    // With French default locale, calling the single-arg overload should return French text
+    Locale.setDefault(Locale.FRANCE);
+    final String description = ResourceUtil.getHolidayDescription("NEW_YEAR");
+    assertThat(description)
+      .as("getHolidayDescription(String) with French default locale should return French description")
+      .isEqualTo("Jour de l'An");
+  }
+
+  @Test
+  void ensureBaseDescriptionIsReturnedForLocaleWithoutDedicatedFileRegardlessOfDefaultLocale() {
+    // The underlying JDK behavior isn't specific to Locale.ENGLISH: ANY locale without its own
+    // dedicated resource file (here: Italian, which jollyday never shipped a translation for)
+    // is affected the same way whenever the JVM default locale happens to be one that DOES have
+    // a dedicated file (here: German).
+    clearCaches();
+    Locale.setDefault(Locale.GERMANY);
+
+    final String countryDescription = ResourceUtil.getCountryDescription(Locale.ITALIAN, "de");
+    assertThat(countryDescription)
+      .as("Country description for 'de' with Locale.ITALIAN should fall back to the base (English) bundle, not German")
+      .isEqualTo("Germany");
+
+    final String holidayDescription = ResourceUtil.getHolidayDescription(Locale.ITALIAN, "NEW_YEAR");
+    assertThat(holidayDescription)
+      .as("Holiday description for 'NEW_YEAR' with Locale.ITALIAN should fall back to the base (English) bundle, not German")
+      .isEqualTo("New Year's Day");
+  }
+
+  @Test
+  void ensureBaseDescriptionIsReturnedForRegionalVariantOfLocaleWithoutDedicatedFile() {
+    // A realistic real-world case: an application configured with a plain US English locale
+    // running on a JVM whose default happens to be a fully-translated language.
+    clearCaches();
+    Locale.setDefault(Locale.GERMANY);
+
+    final String description = ResourceUtil.getCountryDescription(Locale.US, "de");
+    assertThat(description)
+      .as("Country description for 'de' with Locale.US should be in English, not German")
+      .isEqualTo("Germany");
+  }
+
+  @Test
+  void ensureGetResourceBundleNeverMutatesTheJvmDefaultLocale() {
+    clearCaches();
+    Locale.setDefault(Locale.GERMANY);
+
+    ResourceUtil.getCountryDescription(Locale.ENGLISH, "de");
+    ResourceUtil.getHolidayDescription(Locale.ITALIAN, "NEW_YEAR");
+
+    assertThat(Locale.getDefault())
+      .as("Resolving descriptions must never change the JVM-wide default locale as a side effect")
+      .isEqualTo(Locale.GERMANY);
+  }
+
+  @Test
+  void ensureConcurrentResourceBundleResolutionDoesNotCorruptTheSharedDefaultLocale() throws InterruptedException {
+    clearCaches();
+    Locale.setDefault(Locale.GERMANY);
+
+    final int threadCount = 8;
+    final int iterationsPerThread = 200;
+    final ExecutorService executor = Executors.newFixedThreadPool(threadCount + 1);
+    final CountDownLatch start = new CountDownLatch(1);
+    final AtomicBoolean stop = new AtomicBoolean(false);
+    final AtomicInteger corruptedDefaultObservations = new AtomicInteger(0);
+
+    try {
+      // "host application" thread: unrelated code that depends on Locale.getDefault() for
+      // something else entirely (e.g. date/number formatting), running concurrently with
+      // jollyday's resource bundle resolution below.
+      final var watcher = executor.submit(() -> {
+        try {
+          start.await();
+        } catch (InterruptedException ignored) {
+          Thread.currentThread().interrupt();
+        }
+        while (!stop.get()) {
+          if (!Locale.GERMANY.equals(Locale.getDefault())) {
+            corruptedDefaultObservations.incrementAndGet();
+          }
+        }
+      });
+
+      final var workers = new java.util.ArrayList<java.util.concurrent.Future<?>>();
+      for (int t = 0; t < threadCount; t++) {
+        final int threadIndex = t;
+        workers.add(executor.submit(() -> {
+          try {
+            start.await();
+          } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+          }
+          for (int i = 0; i < iterationsPerThread; i++) {
+            // force a cache miss on (nearly) every call with distinct locales
+            final Locale unique = new Locale("en", "X" + threadIndex + "_" + i);
+            ResourceUtil.getCountryDescription(unique, "de");
+          }
+        }));
+      }
+
+      start.countDown();
+      for (final var worker : workers) {
+        worker.get(30, TimeUnit.SECONDS);
+      }
+      stop.set(true);
+      watcher.get(5, TimeUnit.SECONDS);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertThat(corruptedDefaultObservations.get())
+      .as("Locale.getDefault() must remain GERMANY for unrelated concurrent code throughout resolution")
+      .isZero();
+    assertThat(Locale.getDefault())
+      .as("Locale.getDefault() must still be GERMANY after all concurrent resolution has finished")
+      .isEqualTo(Locale.GERMANY);
+  }
+
+  /**
+   * Clears the static caches in ResourceUtil using reflection.
+   * This is necessary to ensure tests run with a clean slate,
+   * as the ResourceBundle caching is static and persistent.
+   */
+  private void clearCaches() {
+    try {
+      final Field countryCacheField = ResourceUtil.class.getDeclaredField("COUNTRY_DESCRIPTIONS_CACHE");
+      countryCacheField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      final java.util.Map<Locale, ResourceBundle> countryCache = (java.util.Map<Locale, ResourceBundle>) countryCacheField.get(null);
+      countryCache.clear();
+
+      final Field holidayCacheField = ResourceUtil.class.getDeclaredField("HOLIDAY_DESCRIPTION_CACHE");
+      holidayCacheField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      final java.util.Map<Locale, ResourceBundle> holidayCache = (java.util.Map<Locale, ResourceBundle>) holidayCacheField.get(null);
+      holidayCache.clear();
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Failed to clear ResourceUtil caches", e);
+    }
+  }
+}


### PR DESCRIPTION
…ault locale

ResourceBundle.getBundle() falls back to Locale.getDefault() before the base bundle when the requested locale has no dedicated resource file. Since there is no country_descriptions_en.properties (the base .properties holds English text), requesting Locale.ENGLISH on a system with a German/French default locale would return German/French descriptions instead of English ones.

The fix temporarily sets the thread default locale to Locale.ROOT during getBundle() calls, forcing ResourceBundle to skip the default-locale fallback and go directly to the base bundle. The original default locale is restored in a finally block, ensuring thread safety.

closes #1294

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
