### PR TITLE
Harden JAXB XML unmarshalling against XXE explicitly

### DIFF
--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapper.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapper.java
@@ -12,6 +12,9 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import java.io.InputStream;
 
 public class JaxbXMLMapper {
@@ -26,6 +29,15 @@ public class JaxbXMLMapper {
   private static final JAXBContext jaxbContext = new JAXBContextCreator().create();
 
   /**
+   * StAX factory hardened against XXE. DTD processing and external entity resolution are
+   * disabled, so a {@code <!DOCTYPE ...>} declaration (and any external or parameter entity it
+   * might carry) is rejected rather than resolved. The protection is configured explicitly here
+   * instead of relying on the defaults of whichever StAX/JAXB provider happens to be on the
+   * classpath, which could change if a consumer swaps or downgrades that provider.
+   */
+  private static final XMLInputFactory XML_INPUT_FACTORY = createHardenedXmlInputFactory();
+
+  /**
    * Unmarshalls the configuration from the stream. Uses <code>JAXB</code> for
    * this.
    *
@@ -38,12 +50,24 @@ public class JaxbXMLMapper {
     }
 
     try {
-      final Unmarshaller um = jaxbContext.createUnmarshaller();
-      @SuppressWarnings("unchecked") final JAXBElement<Configuration> jaxbElement = (JAXBElement<Configuration>) um.unmarshal(stream);
-      return jaxbElement.getValue();
-    } catch (JAXBException exception) {
+      final XMLStreamReader xmlStreamReader = XML_INPUT_FACTORY.createXMLStreamReader(stream);
+      try {
+        final Unmarshaller um = jaxbContext.createUnmarshaller();
+        final JAXBElement<Configuration> jaxbElement = um.unmarshal(xmlStreamReader, Configuration.class);
+        return jaxbElement.getValue();
+      } finally {
+        xmlStreamReader.close();
+      }
+    } catch (JAXBException | XMLStreamException exception) {
       throw new IllegalStateException("Cannot parse holidays XML file.", exception);
     }
+  }
+
+  private static @NonNull XMLInputFactory createHardenedXmlInputFactory() {
+    final XMLInputFactory factory = XMLInputFactory.newFactory();
+    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+    return factory;
   }
 
   private static class JAXBContextCreator {

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapperTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapperTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -17,6 +19,18 @@ class JaxbXMLMapperTest {
   @Test
   void testUnmarshallConfigurationNullCheck() {
     assertThatThrownBy(() -> sut.unmarshallConfiguration(null)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void rejectsXmlWithDoctypeToPreventXxe() {
+    final String maliciousXml =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<!DOCTYPE Configuration [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>\n"
+        + "<Configuration hierarchy=\"test\" description=\"&xxe;\"></Configuration>";
+    final InputStream inputStream = new ByteArrayInputStream(maliciousXml.getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> sut.unmarshallConfiguration(inputStream))
+      .isInstanceOf(IllegalStateException.class);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Parse holiday XML through an XMLInputFactory with SUPPORT_DTD and IS_SUPPORTING_EXTERNAL_ENTITIES disabled instead of unmarshalling the raw InputStream directly. Previously the absence of DTD/external-entity processing relied entirely on the defaults of whichever StAX/JAXB provider was on the classpath, which would silently disappear if a consumer swapped or downgraded that provider.

Add a regression test asserting that XML containing a DOCTYPE declaration is rejected.

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
