### PR TITLE
Harden Jackson XML unmarshalling against XXE explicitly

### DIFF
--- a/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonXMLMapper.java
+++ b/jollyday-jackson/src/main/java/de/focus_shift/jollyday/jackson/JacksonXMLMapper.java
@@ -2,8 +2,10 @@ package de.focus_shift.jollyday.jackson;
 
 import de.focus_shift.jollyday.jackson.mapping.Configuration;
 import org.jspecify.annotations.NonNull;
+import tools.jackson.dataformat.xml.XmlFactory;
 import tools.jackson.dataformat.xml.XmlMapper;
 
+import javax.xml.stream.XMLInputFactory;
 import java.io.InputStream;
 
 import static tools.jackson.databind.PropertyNamingStrategies.UPPER_CAMEL_CASE;
@@ -29,9 +31,23 @@ public class JacksonXMLMapper {
 
   private static class JacksonMapperCreator {
     private @NonNull XmlMapper create() {
-      return XmlMapper.builder()
+      return XmlMapper.builder(XmlFactory.builder().xmlInputFactory(createHardenedXmlInputFactory()).build())
         .propertyNamingStrategy(UPPER_CAMEL_CASE)
         .build();
+    }
+
+    /**
+     * StAX factory hardened against XXE. DTD processing and external entity resolution are
+     * disabled, so a {@code <!DOCTYPE ...>} declaration (and any external or parameter entity it
+     * might carry) is rejected rather than resolved. The protection is configured explicitly here
+     * instead of relying on the defaults of whichever StAX provider happens to be on the classpath,
+     * which could change if a consumer swaps or downgrades that provider.
+     */
+    private @NonNull XMLInputFactory createHardenedXmlInputFactory() {
+      final XMLInputFactory factory = XMLInputFactory.newFactory();
+      factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+      factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+      return factory;
     }
   }
 }

--- a/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/JacksonXMLMapperTest.java
+++ b/jollyday-jackson/src/test/java/de/focus_shift/jollyday/jackson/JacksonXMLMapperTest.java
@@ -1,12 +1,16 @@
 package de.focus_shift.jollyday.jackson;
 
 import de.focus_shift.jollyday.jackson.mapping.Configuration;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class JacksonXMLMapperTest {
 
@@ -17,5 +21,18 @@ class JacksonXMLMapperTest {
     final InputStream inputStream = getClass().getClassLoader().getResourceAsStream("holidays/" + holidayFileName);
     final Configuration configuration = sut.unmarshallConfiguration(inputStream);
     assertThat(configuration.getHolidays()).isNotNull();
+  }
+
+  @Test
+  void rejectsXmlWithDoctypeToPreventXxe() {
+    final JacksonXMLMapper sut = new JacksonXMLMapper();
+    final String maliciousXml =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<!DOCTYPE Configuration [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>\n"
+        + "<Configuration hierarchy=\"test\" description=\"&xxe;\"></Configuration>";
+    final InputStream inputStream = new ByteArrayInputStream(maliciousXml.getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> sut.unmarshallConfiguration(inputStream))
+      .isInstanceOf(IllegalStateException.class);
   }
 }


### PR DESCRIPTION
Build the XmlMapper on an XmlFactory backed by an XMLInputFactory with SUPPORT_DTD and IS_SUPPORTING_EXTERNAL_ENTITIES disabled. Jackson's XML defaults already reject DTDs/external entities, but configuring it explicitly keeps the protection from depending on the defaults of whichever StAX provider happens to be on the classpath.

Add a regression test asserting that XML containing a DOCTYPE declaration is rejected.

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
