### PR TITLE
Remove unused java.xml module dependency from jaxb and jackson modules

### DIFF
--- a/jollyday-jackson/src/main/java/module-info.java
+++ b/jollyday-jackson/src/main/java/module-info.java
@@ -13,7 +13,6 @@ module de.focus_shift.jollyday.jackson {
   requires tools.jackson.databind;
   requires tools.jackson.dataformat.xml;
   requires de.focus_shift.jollyday.core;
-  requires java.xml;
   requires org.slf4j;
   requires org.threeten.extra;
   requires org.jspecify;

--- a/jollyday-jaxb/src/main/java/module-info.java
+++ b/jollyday-jaxb/src/main/java/module-info.java
@@ -11,7 +11,6 @@ module de.focus_shift.jollyday.jaxb {
 
   requires de.focus_shift.jollyday.core;
   requires jakarta.xml.bind;
-  requires java.xml;
   requires org.slf4j;
   requires org.threeten.extra;
   requires org.jspecify;


### PR DESCRIPTION
Neither module references classes from java.xml directly; jakarta.xml.bind and tools.jackson.dataformat.xml already carry whatever they need internally. jollyday-core keeps requires java.xml since XMLValidationTest uses javax.xml.transform.stream.StreamSource to validate the holiday XSD/XML fixtures, and test classes are patched into the main module at compile time.

closes #959

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
