### PR TITLE
Enforce XSD schema validation when unmarshalling holiday XML

### DIFF
--- a/jollyday-core/src/main/java/module-info.java
+++ b/jollyday-core/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module de.focus_shift.jollyday.core {
   opens de.focus_shift.jollyday.core.util;
   opens descriptions;
   opens holidays;
+  opens focus_shift.de.jollyday.schema.holiday;
 
   requires java.xml;
   requires org.slf4j;

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapper.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapper.java
@@ -11,7 +11,13 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.io.IOException;
 import java.io.InputStream;
 
 public class JaxbXMLMapper {
@@ -21,9 +27,16 @@ public class JaxbXMLMapper {
    */
   private static final String PACKAGE = "de.focus_shift.jollyday.jaxb.mapping";
 
+  /**
+   * classpath location of the XSD that bundled and consumer-supplied holiday XML is validated against.
+   */
+  private static final String SCHEMA_RESOURCE = "focus_shift.de/jollyday/schema/holiday/holiday.xsd";
+
   private static final Logger LOG = LoggerFactory.getLogger(JaxbXMLMapper.class);
 
   private static final JAXBContext jaxbContext = new JAXBContextCreator().create();
+
+  private static final Schema holidaySchema = loadSchema();
 
   /**
    * Unmarshalls the configuration from the stream. Uses <code>JAXB</code> for
@@ -39,10 +52,23 @@ public class JaxbXMLMapper {
 
     try {
       final Unmarshaller um = jaxbContext.createUnmarshaller();
+      um.setSchema(holidaySchema);
       @SuppressWarnings("unchecked") final JAXBElement<Configuration> jaxbElement = (JAXBElement<Configuration>) um.unmarshal(stream);
       return jaxbElement.getValue();
     } catch (JAXBException exception) {
       throw new IllegalStateException("Cannot parse holidays XML file.", exception);
+    }
+  }
+
+  private static @NonNull Schema loadSchema() {
+    try (InputStream schemaStream = ClassLoadingUtil.getClassloader().getResourceAsStream(SCHEMA_RESOURCE)) {
+      if (schemaStream == null) {
+        throw new IllegalStateException("Cannot find holiday schema on the classpath: " + SCHEMA_RESOURCE);
+      }
+      final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+      return schemaFactory.newSchema(new StreamSource(schemaStream));
+    } catch (IOException | SAXException exception) {
+      throw new IllegalStateException("Cannot load holiday schema: " + SCHEMA_RESOURCE, exception);
     }
   }
 

--- a/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapper.java
+++ b/jollyday-jaxb/src/main/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapper.java
@@ -11,10 +11,16 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.io.IOException;
 import java.io.InputStream;
 
 public class JaxbXMLMapper {
@@ -23,6 +29,11 @@ public class JaxbXMLMapper {
    * the package name to search for the generated java classes.
    */
   private static final String PACKAGE = "de.focus_shift.jollyday.jaxb.mapping";
+
+  /**
+   * classpath location of the XSD that bundled and consumer-supplied holiday XML is validated against.
+   */
+  private static final String SCHEMA_RESOURCE = "focus_shift.de/jollyday/schema/holiday/holiday.xsd";
 
   private static final Logger LOG = LoggerFactory.getLogger(JaxbXMLMapper.class);
 
@@ -36,6 +47,13 @@ public class JaxbXMLMapper {
    * classpath, which could change if a consumer swaps or downgrades that provider.
    */
   private static final XMLInputFactory XML_INPUT_FACTORY = createHardenedXmlInputFactory();
+
+  /**
+   * the holiday XSD every configuration is validated against while unmarshalling, so that structural
+   * mistakes like elements out of the schema's declared sequence order fail fast instead of being
+   * silently ignored by JAXB.
+   */
+  private static final Schema HOLIDAY_SCHEMA = loadSchema(ClassLoadingUtil.getClassloader());
 
   /**
    * Unmarshalls the configuration from the stream. Uses <code>JAXB</code> for
@@ -53,6 +71,7 @@ public class JaxbXMLMapper {
       final XMLStreamReader xmlStreamReader = XML_INPUT_FACTORY.createXMLStreamReader(stream);
       try {
         final Unmarshaller um = jaxbContext.createUnmarshaller();
+        um.setSchema(HOLIDAY_SCHEMA);
         final JAXBElement<Configuration> jaxbElement = um.unmarshal(xmlStreamReader, Configuration.class);
         return jaxbElement.getValue();
       } finally {
@@ -63,10 +82,33 @@ public class JaxbXMLMapper {
     }
   }
 
+  static @NonNull Schema loadSchema(@NonNull final ClassLoader classLoader) {
+    try (InputStream schemaStream = classLoader.getResourceAsStream(SCHEMA_RESOURCE)) {
+      if (schemaStream == null) {
+        throw new IllegalStateException("Cannot find holiday schema on the classpath: " + SCHEMA_RESOURCE);
+      }
+      return createHardenedSchemaFactory().newSchema(new StreamSource(schemaStream));
+    } catch (IOException | SAXException exception) {
+      throw new IllegalStateException("Cannot load holiday schema: " + SCHEMA_RESOURCE, exception);
+    }
+  }
+
   private static @NonNull XMLInputFactory createHardenedXmlInputFactory() {
     final XMLInputFactory factory = XMLInputFactory.newFactory();
     factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
     factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+    return factory;
+  }
+
+  /**
+   * Schema factory hardened against XXE. External DTDs and external schema documents are not
+   * accessed while the holiday XSD is compiled, so neither the bundled schema nor a replacement on a
+   * consumer's classpath can pull in a document from the file system or the network.
+   */
+  private static @NonNull SchemaFactory createHardenedSchemaFactory() throws SAXException {
+    final SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+    factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
     return factory;
   }
 

--- a/jollyday-jaxb/src/main/java/module-info.java
+++ b/jollyday-jaxb/src/main/java/module-info.java
@@ -11,6 +11,7 @@ module de.focus_shift.jollyday.jaxb {
 
   requires de.focus_shift.jollyday.core;
   requires jakarta.xml.bind;
+  requires java.xml;
   requires org.slf4j;
   requires org.threeten.extra;
   requires org.jspecify;

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/JaxbConfigurationServiceTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/JaxbConfigurationServiceTest.java
@@ -30,7 +30,7 @@ class JaxbConfigurationServiceTest {
     final URL url = mock(URL.class);
     when(parameter.createResourceUrl()).thenReturn(url);
     // Provide a minimal valid XML for unmarshalling with correct namespace
-    final String xml = "<Configuration xmlns=\"https://focus_shift.de/jollyday/schema/holiday\"></Configuration>";
+    final String xml = "<Configuration xmlns=\"https://focus_shift.de/jollyday/schema/holiday\"><Holidays/></Configuration>";
     final InputStream stream = new ByteArrayInputStream(xml.getBytes());
     when(url.openStream()).thenReturn(stream);
 

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/JaxbConfigurationServiceTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/JaxbConfigurationServiceTest.java
@@ -29,8 +29,8 @@ class JaxbConfigurationServiceTest {
     final ManagerParameter parameter = mock(ManagerParameter.class);
     final URL url = mock(URL.class);
     when(parameter.createResourceUrl()).thenReturn(url);
-    // Provide a minimal valid XML for unmarshalling with correct namespace
-    final String xml = "<Configuration xmlns=\"https://focus_shift.de/jollyday/schema/holiday\"></Configuration>";
+    // Provide a minimal schema valid XML for unmarshalling with correct namespace
+    final String xml = "<Configuration xmlns=\"https://focus_shift.de/jollyday/schema/holiday\"><Holidays/></Configuration>";
     final InputStream stream = new ByteArrayInputStream(xml.getBytes());
     when(url.openStream()).thenReturn(stream);
 

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapperTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapperTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -25,5 +27,24 @@ class JaxbXMLMapperTest {
     final InputStream inputStream = getClass().getClassLoader().getResourceAsStream("holidays/" + holidayFileName);
     final Configuration configuration = sut.unmarshallConfiguration(inputStream);
     assertThat(configuration.getHolidays()).isNotNull();
+  }
+
+  @Test
+  void rejectsHolidayElementsThatViolateTheSchemasDeclaredSequenceOrder() {
+    final String outOfOrderXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+      "<Configuration hierarchy=\"xx\" description=\"Test\"\n" +
+      "               xmlns=\"https://focus_shift.de/jollyday/schema/holiday\"\n" +
+      "               xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+      "               xsi:schemaLocation=\"https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd\">\n" +
+      "  <Holidays>\n" +
+      "    <ChristianHoliday type=\"GOOD_FRIDAY\"/>\n" +
+      "    <Fixed month=\"JANUARY\" day=\"1\" descriptionPropertiesKey=\"NEW_YEAR\"/>\n" +
+      "  </Holidays>\n" +
+      "</Configuration>\n";
+
+    final InputStream inputStream = new ByteArrayInputStream(outOfOrderXml.getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> sut.unmarshallConfiguration(inputStream))
+      .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapperTest.java
+++ b/jollyday-jaxb/src/test/java/de/focus_shift/jollyday/jaxb/JaxbXMLMapperTest.java
@@ -4,8 +4,10 @@ import de.focus_shift.jollyday.jaxb.mapping.Configuration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
@@ -33,11 +35,71 @@ class JaxbXMLMapperTest {
       .isInstanceOf(IllegalStateException.class);
   }
 
+  @Test
+  void rejectsHolidayElementsThatViolateTheSchemasDeclaredSequenceOrder() {
+    final String outOfOrderXml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <Configuration hierarchy="xx" description="Test" xmlns="https://focus_shift.de/jollyday/schema/holiday">
+        <Holidays>
+          <ChristianHoliday type="GOOD_FRIDAY"/>
+          <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
+        </Holidays>
+      </Configuration>
+      """;
+    final InputStream inputStream = new ByteArrayInputStream(outOfOrderXml.getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> sut.unmarshallConfiguration(inputStream))
+      .isInstanceOf(IllegalStateException.class);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"Holidays_at.xml", "Holidays_de.xml", "Holidays_gb.xml", "Holidays_ua.xml", "Holidays_tr.xml", "Holidays_za.xml"})
   void unmarshalRealResource(String holidayFileName) {
     final InputStream inputStream = getClass().getClassLoader().getResourceAsStream("holidays/" + holidayFileName);
     final Configuration configuration = sut.unmarshallConfiguration(inputStream);
     assertThat(configuration.getHolidays()).isNotNull();
+  }
+
+  @Test
+  void failsWhenTheHolidaySchemaIsNotOnTheClassPath() {
+    final ClassLoader withoutSchema = classLoaderProviding(null);
+
+    assertThatThrownBy(() -> JaxbXMLMapper.loadSchema(withoutSchema))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Cannot find holiday schema on the classpath: focus_shift.de/jollyday/schema/holiday/holiday.xsd")
+      .hasNoCause();
+  }
+
+  @Test
+  void failsWhenTheHolidaySchemaResourceIsNotASchema() {
+    final ClassLoader withBrokenSchema = classLoaderProviding(new ByteArrayInputStream("<not-a-schema/>".getBytes(StandardCharsets.UTF_8)));
+
+    assertThatThrownBy(() -> JaxbXMLMapper.loadSchema(withBrokenSchema))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Cannot load holiday schema: focus_shift.de/jollyday/schema/holiday/holiday.xsd")
+      .hasCauseInstanceOf(SAXException.class);
+  }
+
+  @Test
+  void failsWhenTheHolidaySchemaResourceCannotBeRead() {
+    final ClassLoader withUnreadableSchema = classLoaderProviding(new InputStream() {
+      @Override
+      public int read() throws IOException {
+        throw new IOException("schema resource is not readable");
+      }
+    });
+
+    assertThatThrownBy(() -> JaxbXMLMapper.loadSchema(withUnreadableSchema))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Cannot load holiday schema: focus_shift.de/jollyday/schema/holiday/holiday.xsd");
+  }
+
+  private static ClassLoader classLoaderProviding(final InputStream resource) {
+    return new ClassLoader(JaxbXMLMapperTest.class.getClassLoader()) {
+      @Override
+      public InputStream getResourceAsStream(final String name) {
+        return resource;
+      }
+    };
   }
 }


### PR DESCRIPTION
## Summary
- `JaxbXMLMapper.unmarshallConfiguration` attached no schema to the `Unmarshaller`, so structural mistakes went unnoticed: elements out of the order the XSD declares in its sequence, a missing mandatory `Holidays` block or an invalid enum value were silently accepted or misbound by JAXB instead of raising an error. That affects the bundled calendars as much as any XML a consumer supplies through `URLConfigurationProvider`.
- The bundled `holiday.xsd` is now compiled once and set on every `Unmarshaller`, so structurally invalid configuration fails fast with a validation error.
- The `SchemaFactory` is configured without access to external DTDs and external schema documents (`ACCESS_EXTERNAL_DTD` / `ACCESS_EXTERNAL_SCHEMA`), in the same spirit as the `XMLInputFactory` hardened in #1311, so compiling the schema cannot pull in a document from the file system or the network. This also resolves the code scanning alert raised on the previous revision of this branch.
- Loading the schema from the classpath needs the resource package `focus_shift.de.jollyday.schema.holiday` opened in `jollyday-core`.
- The minimal configuration in `JaxbConfigurationServiceTest` was not actually schema valid, as the `Holidays` element is mandatory.

Rebased onto current `main`, so the change sits on top of the StAX based unmarshalling from #1311.

Stacked on #1481, which repairs the currently red build of `main` (missing `requires java.xml;` in `jollyday-jackson`) and is needed to build this branch at all.

## Test plan
- [x] `rejectsHolidayElementsThatViolateTheSchemasDeclaredSequenceOrder` written first, confirmed it failed against the unvalidated unmarshaller (no exception at all for out of order elements), then confirmed it passes with the schema attached
- [x] The three schema loading failure paths are covered and were checked by mutation: removing the null guard or wrapping the cause in a different exception type makes exactly those tests fail
- [x] `./mvnw verify` passes for all modules, so every bundled calendar validates against the XSD
- [x] `./mvnw verify -Dtests.groups=BenchmarkTest` passes; manager creation with caching disabled measures 26,587 ops/s against a reference score of 1,200