### PR TITLE
Verify every referenced holiday description key has a translation

### DIFF
--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions.properties
@@ -21,6 +21,7 @@ holiday.description.ALL_SAINTS                                                  
 holiday.description.ALL_SOULS                                                           = All Souls
 holiday.description.ALMUDENA_DAY                                                        = Virgen of Almudena
 holiday.description.AMAZIGH_NEW_YEAR                                                    = Amazigh New Year
+holiday.description.AMBEDKAR_JAYANTI                                                    = Ambedkar Jayanti
 holiday.description.AMERICAN_INDIAN_HERITAGE_DAY                                        = American Indian Heritage Day
 holiday.description.AMERICAS_DAY                                                        = America's Day
 holiday.description.ANCESTRY_DAY                                                        = Ancestry Day
@@ -303,6 +304,7 @@ holiday.description.KADOOMENT_DAY                                               
 holiday.description.KALANIANAOLE                                                        = Prince Jonah Kuhio Kalanianaole Day
 holiday.description.KAMEHAMEHA                                                          = Kamehameha Day
 holiday.description.KAMUZU_BANDA                                                        = President Kamuzu Banda's Birthday
+holiday.description.KARNATAKA_RAJYOTSAVA                                                = Karnataka Rajyotsava
 holiday.description.KARUME_DAY                                                          = Karume Day
 holiday.description.KASHMIR_DAY                                                         = Kashmir Day
 holiday.description.KENNETH_KAUNDA_BIRTHDAY                                             = Kenneth Kaunda's Birthday
@@ -383,12 +385,14 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = National Day of Community Service
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = National Day of Democracy
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = National Day of Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = National Day of Mourning (death of Néstor Kirchner)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = National Day of Prayer
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = National Day of Prayer and Thanksgiving
 holiday.description.NATIONAL_DAY_OF_THANKSGIVING                                        = National Day of Thanksgiving
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = National day of Zumbi and black awareness
 holiday.description.NATIONAL_DECORATION_DAY                                             = National Decoration Day
 holiday.description.NATIONAL_HEALTH_DAY                                                 = National Health Day
+holiday.description.NATIONAL_HERITAGE_DAY                                               = National Heritage Day
 holiday.description.NATIONAL_HEROES_AND_BENEFACTORS_DAY                                 = National Heroes and Benefactors Day
 holiday.description.NATIONAL_HEROES_AND_HEROINES_DAY                                    = National Heroes and Heroines Day
 holiday.description.NATIONAL_HEROES_DAY                                                 = National Heroes Day
@@ -493,6 +497,7 @@ holiday.description.SABA_SABA_DAY                                               
 holiday.description.SAINT_CLEMENT                                                       = Saint Clement of Ohrid day
 holiday.description.SAINT_GEORGES_CAYE_DAY                                              = Saint George's Caye Day
 holiday.description.SAINT_ISIDORE                                                       = San Isidro
+holiday.description.SAINT_JEAN_BAPTISTE_DAY                                             = Saint-Jean-Baptiste Day
 holiday.description.SAINT_MARONS                                                        = Feast of Saint Maron
 holiday.description.SAO_TOME_DAY                                                        = Sao Tome Day
 holiday.description.SAINT_OLAV_DAY                                                      = Saint Olav Day
@@ -518,6 +523,7 @@ holiday.description.SETTLER                                                     
 holiday.description.SEWARD                                                              = Seward's Day
 holiday.description.SG50_PUBLIC_HOLIDAY                                                 = SG50 Public Holiday
 holiday.description.SHACKLETON_DAY                                                      = Shackleton Day
+holiday.description.SHIVAJI_JAYANTI                                                     = Chhatrapati Shivaji Maharaj Jayanti
 holiday.description.SHOWA_DAY                                                           = Showa Day
 holiday.description.SIR_HAMMER_DEROBURT_DAY                                             = Sir Hammer DeRoburt Day
 holiday.description.SIR_SERETSE_KHAMA_DAY                                               = Sir Seretse Khama Day
@@ -552,11 +558,13 @@ holiday.description.ST_DEMETRIUS                                                
 holiday.description.ST_DEVOTA                                                           = Saint Devota's Day
 holiday.description.ST_ELIJAH                                                           = St.Elijah's Day
 holiday.description.ST_FRANCIS_OF_ASSISI                                                = St. Francis of Assisi's Day
+holiday.description.ST_FRANCIS_XAVIER                                                   = Feast of St. Francis Xavier
 holiday.description.ST_GEORGE                                                           = St.George Day
 holiday.description.ST_GERARD                                                           = St. Gerard's Day
 holiday.description.ST_GRATUS                                                           = St. Gratus' Day
 holiday.description.ST_HELENA_DAY                                                       = St Helena Day
 holiday.description.ST_JAMES                                                            = St. James Day
+holiday.description.ST_JANUARIUS                                                        = Feast of Saint Januarius
 holiday.description.ST_JOHN                                                             = St. John's Day
 holiday.description.ST_JOSEPH                                                           = St. Josephs day
 holiday.description.ST_JOSEPH_WORKER                                                    = Saint Joseph the Worker
@@ -577,6 +585,7 @@ holiday.description.ST_URSULA                                                   
 holiday.description.ST_VIGILIUS                                                         = St. Vigilius' Day
 holiday.description.ST_VITALIAN                                                         = St. Vitalian's Day
 holiday.description.ST_VITUS                                                            = St.Vitus' Day
+holiday.description.SUBHAS_CHANDRA_BOSE_JAYANTI                                         = Subhas Chandra Bose Jayanti
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.SYRIAN_REVOLUTION_DAY                                               = Syrian Revolution Day
 holiday.description.TAKAI_COMMISSION_HOLIDAY                                            = Takai Commission Holiday

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_de.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_de.properties
@@ -21,6 +21,7 @@ holiday.description.ALL_SAINTS                                                  
 holiday.description.ALL_SOULS                                                           = Aller Seelen
 holiday.description.ALMUDENA_DAY                                                        = Tag der Jungfrau von Almudena
 holiday.description.AMAZIGH_NEW_YEAR                                                    = Amazigh-Neujahr
+holiday.description.AMBEDKAR_JAYANTI                                                    = Ambedkar Jayanti
 holiday.description.AMERICAN_INDIAN_HERITAGE_DAY                                        = Tag des indianischen Erbes
 holiday.description.AMERICAS_DAY                                                        = Amerikas Tag
 holiday.description.ANCESTRY_DAY                                                        = Tag der Vorfahren
@@ -303,6 +304,7 @@ holiday.description.KADOOMENT_DAY                                               
 holiday.description.KALANIANAOLE                                                        = Prinz Jonah Kuhio Kalanianaole Tag
 holiday.description.KAMEHAMEHA                                                          = Kamehameha Tag
 holiday.description.KAMUZU_BANDA                                                        = Geburtstag von Präsident Kamuzu Banda
+holiday.description.KARNATAKA_RAJYOTSAVA                                                = Karnataka Rajyotsava
 holiday.description.KARUME_DAY                                                          = Karume-Tag
 holiday.description.KASHMIR_DAY                                                         = Kaschmir-Tag
 holiday.description.KENNETH_KAUNDA_BIRTHDAY                                             = Geburtstag von Kenneth Kaunda
@@ -383,12 +385,14 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Nationaler Tag des Gemeinschaftsdienstes
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Nationaler Tag der Demokratie
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Nationaler Tag von Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Nationaler Trauertag (Tod von Néstor Kirchner)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Nationaler Gebetstag
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Nationaler Gebets- und Erntedanktag
 holiday.description.NATIONAL_DAY_OF_THANKSGIVING                                        = Nationaler Danktag
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Nationaler Tag von Zumbi und schwarzem Bewusstsein
 holiday.description.NATIONAL_DECORATION_DAY                                             = Nationaler Dekorationstag
 holiday.description.NATIONAL_HEALTH_DAY                                                 = Nationaler Gesundheitstag
+holiday.description.NATIONAL_HERITAGE_DAY                                               = Nationaler Tag des Kulturerbes
 holiday.description.NATIONAL_HEROES_AND_BENEFACTORS_DAY                                 = Tag der nationalen Helden und Wohltäter
 holiday.description.NATIONAL_HEROES_AND_HEROINES_DAY                                    = Tag der Nationalhelden und -heldinnen
 holiday.description.NATIONAL_HEROES_DAY                                                 = Tag der Nationalhelden
@@ -492,6 +496,7 @@ holiday.description.SABA_DAY                                                    
 holiday.description.SABA_SABA_DAY                                                       = Saba Saba Tag
 holiday.description.SAINT_CLEMENT                                                       = St. Clement von Ohrid Tag
 holiday.description.SAINT_GEORGES_CAYE_DAY                                              = Saint-George's-Caye-Tag
+holiday.description.SAINT_JEAN_BAPTISTE_DAY                                             = Saint-Jean-Baptiste-Tag
 holiday.description.SAO_TOME_DAY                                                        = Tag von Sao Tome
 holiday.description.SAINT_ISIDORE                                                       = Heiliger Isidor
 holiday.description.SAINT_MARONS                                                        = Fest des heiligen Maron
@@ -518,6 +523,7 @@ holiday.description.SETTLER                                                     
 holiday.description.SEWARD                                                              = Sewards Tag
 holiday.description.SG50_PUBLIC_HOLIDAY                                                 = SG50 Feiertag
 holiday.description.SHACKLETON_DAY                                                      = Shackleton-Tag
+holiday.description.SHIVAJI_JAYANTI                                                     = Chhatrapati Shivaji Maharaj Jayanti
 holiday.description.SHOWA_DAY                                                           = Showa Tag
 holiday.description.SIR_HAMMER_DEROBURT_DAY                                             = Sir-Hammer-DeRoburt-Tag
 holiday.description.SIR_SERETSE_KHAMA_DAY                                               = Sir Seretse Khama-Tag
@@ -552,11 +558,13 @@ holiday.description.ST_DEMETRIUS                                                
 holiday.description.ST_DEVOTA                                                           = Tag der Heiligen Devota
 holiday.description.ST_ELIJAH                                                           = St. Elijah's Tag
 holiday.description.ST_FRANCIS_OF_ASSISI                                                = Franz von Assisi-Tag
+holiday.description.ST_FRANCIS_XAVIER                                                   = Fest des Heiligen Franz Xaver
 holiday.description.ST_GEORGE                                                           = St. George Tag
 holiday.description.ST_GERARD                                                           = Tag des Heiligen Gerhard
 holiday.description.ST_GRATUS                                                           = Tag des Heiligen Gratus
 holiday.description.ST_HELENA_DAY                                                       = Tag der Heiligen Helena
 holiday.description.ST_JAMES                                                            = St. James Tag
+holiday.description.ST_JANUARIUS                                                        = Fest des Heiligen Januarius
 holiday.description.ST_JOHN                                                             = St. Johns Tag
 holiday.description.ST_JOSEPH                                                           = St. Josephs Tag
 holiday.description.ST_JOSEPH_WORKER                                                    = Tag des heiligen Josef des Arbeiters
@@ -577,6 +585,7 @@ holiday.description.ST_URSULA                                                   
 holiday.description.ST_VIGILIUS                                                         = Tag des Heiligen Vigilius
 holiday.description.ST_VITALIAN                                                         = Tag des Heiligen Vitalian
 holiday.description.ST_VITUS                                                            = St.Vitus' Tag
+holiday.description.SUBHAS_CHANDRA_BOSE_JAYANTI                                         = Subhas Chandra Bose Jayanti
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.SYRIAN_REVOLUTION_DAY                                               = Syrischer Revolutionstag
 holiday.description.TAKAI_COMMISSION_HOLIDAY                                            = Takai-Kommissions-Feiertag

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_el.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_el.properties
@@ -21,6 +21,7 @@ holiday.description.ALMUDENA_DAY                                                
 holiday.description.AMAZIGH_NEW_YEAR                                                    = Πρωτοχρονιά των Αμαζώνων
 holiday.description.AGRICULTURAL_REFORM_DAY                                             = Ημέρα Αγροτικής Μεταρρύθμισης
 holiday.description.AGRICULTURAL_SHOW                                                   = Ημέρα Αγροτικής Έκθεσης του Νησιού Νόρφολκ
+holiday.description.AMBEDKAR_JAYANTI                                                    = Ambedkar Jayanti
 holiday.description.AMERICAN_INDIAN_HERITAGE_DAY                                        = Ημέρα Κληρονομιάς των Ινδιάνων της Αμερικής
 holiday.description.AMERICAS_DAY                                                        = Ημέρα της Αμερικής
 holiday.description.ANCESTRY_DAY                                                        = Ημέρα των Προγόνων
@@ -53,6 +54,8 @@ holiday.description.AUGUST_BANK_HOLIDAY                                         
 holiday.description.AUGUST_FESTIVALS                                                    = Φεστιβάλ Αυγούστου
 holiday.description.AUGUST_MONDAY                                                       = Δευτέρα Αυγούστου
 holiday.description.AUGUST_THURSDAY                                                     = Πέμπτη Αυγούστου
+holiday.description.AUTONOMY_DAY                                                        = Ημέρα Αυτονομίας
+holiday.description.AZORES_DAY                                                          = Ημέρα της Αυτόνομης Περιφέρειας των Αζορών
 holiday.description.BANK_HOLIDAY                                                        = Τραπεζική αργία
 holiday.description.BATTLE_BOYNE                                                        = Μάχη του Boyne
 holiday.description.BATTLE_DAY                                                          = Ημέρα της Μάχης
@@ -212,6 +215,7 @@ holiday.description.FIRST_CHRISTMAS_DAY                                         
 holiday.description.FIRST_DAY_OF_JANUARY                                                = Η πρώτη ημέρα του Ιανουαρίου
 holiday.description.FIRST_DAY_SUMMER                                                    = Πρώτη ημέρα του καλοκαιριού
 holiday.description.FIRST_MARTYR                                                        = Πρώτος Μάρτυρας
+holiday.description.FIRST_OCTAVE                                                        = Πρώτη Ογδόη
 holiday.description.FIRST_WEEKDAY_AFTER_CHRISTMAS                                       = Η πρώτη εργάσιμη ημέρα μετά την ημέρα των Χριστουγέννων
 holiday.description.FISHERMENS_DAY                                                      = Ημέρα των Ψαράδων
 holiday.description.FLAG_AND_UNIVERSITIES_DAY                                           = Ημέρα Σημαίας και Πανεπιστημίων
@@ -300,6 +304,7 @@ holiday.description.KADOOMENT_DAY                                               
 holiday.description.KALANIANAOLE                                                        = Ημέρα του πρίγκιπα Jonah Kuhio Kalanianaole
 holiday.description.KAMEHAMEHA                                                          = Ημέρα Kamehameha
 holiday.description.KAMUZU_BANDA                                                        = Τα γενέθλια του Προέδρου Kamuzu Banda
+holiday.description.KARNATAKA_RAJYOTSAVA                                                = Karnataka Rajyotsava
 holiday.description.KARUME_DAY                                                          = Ημέρα Karume
 holiday.description.KASHMIR_DAY                                                         = Ημέρα Kaschmir
 holiday.description.KENNETH_KAUNDA_BIRTHDAY                                             = Τα γενέθλια του Kenneth Kaunda
@@ -336,6 +341,7 @@ holiday.description.LOTU_O_TAMAITI                                              
 holiday.description.LOUIS_RIEL                                                          = Ημέρα Louis Riel
 holiday.description.LUNAR_NEW_YEARS_DAY                                                 = Ημέρα της Σεληνιακής Πρωτοχρονιάς
 holiday.description.MADARAKA_DAY                                                        = Ημέρα Madaraka
+holiday.description.MADEIRA_DAY                                                         = Ημέρα της Αυτόνομης Περιφέρειας της Μαδέρας και των Κοινοτήτων της Μαδέρας
 holiday.description.MADONNA_DELLA_SALUTE                                                = Γιορτή της Παναγίας της Υγείας
 holiday.description.MAHA_SHIVRATREE                                                     = Maha Shivaratree
 holiday.description.MAJORITY_RULE_DAY                                                   = Ημέρα της πλειοψηφίας
@@ -379,12 +385,14 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Εθνική Ημέρα Κοινοτικής Υπηρεσίας
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Εθνική Ημέρα της Δημοκρατίας
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Εθνική Ημέρα του Γιβραλτάρ
+holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Εθνική Ημέρα Πένθους (θάνατος του Νέστορ Κίρχνερ)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Εθνική ημέρα προσευχής
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Εθνική ημέρα προσευχής και ευχαριστιών
 holiday.description.NATIONAL_DAY_OF_THANKSGIVING                                        = Εθνική Ημέρα Ευχαριστίας
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Εθνική Ημέρα του Ζουμπί και της Μαύρης Συνείδησης
 holiday.description.NATIONAL_DECORATION_DAY                                             = Εθνική ημέρα διακόσμησης
 holiday.description.NATIONAL_HEALTH_DAY                                                 = Εθνική Ημέρα Υγείας
+holiday.description.NATIONAL_HERITAGE_DAY                                               = Εθνική Ημέρα Πολιτιστικής Κληρονομιάς
 holiday.description.NATIONAL_HEROES_AND_BENEFACTORS_DAY                                 = Ημέρα των Εθνικών Ηρώων και Ευεργετών
 holiday.description.NATIONAL_HEROES_AND_HEROINES_DAY                                    = Ημέρα Εθνικών Ηρώων και Ηρωίδων
 holiday.description.NATIONAL_HEROES_DAY                                                 = Ημέρα Εθνικών Ηρώων
@@ -488,6 +496,7 @@ holiday.description.SABA_DAY                                                    
 holiday.description.SABA_SABA_DAY                                                       = Ημέρα Saba Saba
 holiday.description.SAINT_CLEMENT                                                       = Ημέρα Αγίου Κλήμεντος της Αχρίδας
 holiday.description.SAINT_GEORGES_CAYE_DAY                                              = Ημέρα του Σεντ Τζορτζ Κέι
+holiday.description.SAINT_JEAN_BAPTISTE_DAY                                             = Ημέρα Saint-Jean-Baptiste
 holiday.description.SAO_TOME_DAY                                                        = Ημέρα του Αγίου Θωμά
 holiday.description.SAINT_ISIDORE                                                       = Heiliger Isidor
 holiday.description.SAINT_MARONS                                                        = Εορτή του Αγίου Μαρωνίτη
@@ -514,6 +523,7 @@ holiday.description.SETTLER                                                     
 holiday.description.SEWARD                                                              = Ημέρα του Seward
 holiday.description.SG50_PUBLIC_HOLIDAY                                                 = Δημόσια αργία SG50
 holiday.description.SHACKLETON_DAY                                                      = Ημέρα Shackleton
+holiday.description.SHIVAJI_JAYANTI                                                     = Chhatrapati Shivaji Maharaj Jayanti
 holiday.description.SHOWA_DAY                                                           = Showa Day
 holiday.description.SIR_HAMMER_DEROBURT_DAY                                             = Ημέρα Sir Hammer DeRoburt
 holiday.description.SIR_SERETSE_KHAMA_DAY                                               = Ημέρα του Σερ Σερέτσε Χάμα
@@ -548,11 +558,13 @@ holiday.description.ST_DEMETRIUS                                                
 holiday.description.ST_DEVOTA                                                           = Ημέρα της Αγίας Δεβότα
 holiday.description.ST_ELIJAH                                                           = Ημέρα του Αγίου Ηλία
 holiday.description.ST_FRANCIS_OF_ASSISI                                                = Ημέρα του Αγίου Φραγκίσκου της Ασίζης
+holiday.description.ST_FRANCIS_XAVIER                                                   = Εορτή του Αγίου Φραγκίσκου Ξαβιέ
 holiday.description.ST_GEORGE                                                           = Ημέρα του Αγίου Γεωργίου
 holiday.description.ST_GERARD                                                           = Ημέρα του Αγίου Γεράρδου
 holiday.description.ST_GRATUS                                                           = Ημέρα του Αγίου Γράτου
 holiday.description.ST_HELENA_DAY                                                       = Ημέρα της Αγίας Ελένης
 holiday.description.ST_JAMES                                                            = Ημέρα του Αγίου Ιακώβου
+holiday.description.ST_JANUARIUS                                                        = Εορτή του Αγίου Ιανουαρίου
 holiday.description.ST_JOHN                                                             = Ημέρα του Αγίου Ιωάννη
 holiday.description.ST_JOSEPH                                                           = Ημέρα του Αγίου Ιωσήφ
 holiday.description.ST_JOSEPH_WORKER                                                    = Ημέρα του Αγίου Ιωσήφ του Εργάτη
@@ -573,6 +585,7 @@ holiday.description.ST_URSULA                                                   
 holiday.description.ST_VIGILIUS                                                         = Ημέρα του Αγίου Βιγιλίου
 holiday.description.ST_VITALIAN                                                         = Ημέρα του Αγίου Βιταλιανού
 holiday.description.ST_VITUS                                                            = Ημέρα του Αγίου Βίτου
+holiday.description.SUBHAS_CHANDRA_BOSE_JAYANTI                                         = Subhas Chandra Bose Jayanti
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Καλοκαιρινές διακοπές
 holiday.description.SYRIAN_REVOLUTION_DAY                                               = Ημέρα της Συριακής Επανάστασης
 holiday.description.TAKAI_COMMISSION_HOLIDAY                                            = Αργία Επιτροπής Takai

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_fr.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_fr.properties
@@ -21,6 +21,7 @@ holiday.description.ALL_SAINTS                                                  
 holiday.description.ALL_SOULS                                                           = Toutes les Âmes
 holiday.description.ALMUDENA_DAY                                                        = Jour de la Vierge de l’Almudena
 holiday.description.AMAZIGH_NEW_YEAR                                                    = Nouvel An amazigh
+holiday.description.AMBEDKAR_JAYANTI                                                    = Ambedkar Jayanti
 holiday.description.AMERICAN_INDIAN_HERITAGE_DAY                                        = Journée du Patrimoine des Amérindiens
 holiday.description.AMERICAS_DAY                                                        = Jour de l’Amérique
 holiday.description.ANCESTRY_DAY                                                        = Jour des ancêtres
@@ -53,6 +54,8 @@ holiday.description.AUGUST_BANK_HOLIDAY                                         
 holiday.description.AUGUST_FESTIVALS                                                    = Festivals d'Août
 holiday.description.AUGUST_MONDAY                                                       = Lundi d'août
 holiday.description.AUGUST_THURSDAY                                                     = Jeudi d'août
+holiday.description.AUTONOMY_DAY                                                        = Jour de l'Autonomie
+holiday.description.AZORES_DAY                                                          = Jour de la Région autonome des Açores
 holiday.description.BANK_HOLIDAY                                                        = Journée férié
 holiday.description.BATTLE_BOYNE                                                        = Bataille du Boyne
 holiday.description.BATTLE_DAY                                                          = Jour de la Bataille
@@ -212,6 +215,7 @@ holiday.description.FIRST_CHRISTMAS_DAY                                         
 holiday.description.FIRST_DAY_OF_JANUARY                                                = Le premier jour du mois de janvier
 holiday.description.FIRST_DAY_SUMMER                                                    = Premier jour de l'Été
 holiday.description.FIRST_MARTYR                                                        = Premier Martyr
+holiday.description.FIRST_OCTAVE                                                        = Première Octave
 holiday.description.FIRST_WEEKDAY_AFTER_CHRISTMAS                                       = Le premier jour de semaine après le jour de Noël
 holiday.description.FISHERMENS_DAY                                                      = Journée des pêcheurs
 holiday.description.FLAG_AND_UNIVERSITIES_DAY                                           = Jour du drapeau et des universités
@@ -300,6 +304,7 @@ holiday.description.KADOOMENT_DAY                                               
 holiday.description.KALANIANAOLE                                                        = Prince Jonah Kuhio Kalanianaole Day
 holiday.description.KAMEHAMEHA                                                          = Kamehameha Day
 holiday.description.KAMUZU_BANDA                                                        = Anniversaire du Président Kamuzu Banda
+holiday.description.KARNATAKA_RAJYOTSAVA                                                = Karnataka Rajyotsava
 holiday.description.KARUME_DAY                                                          = Jour de Karume
 holiday.description.KASHMIR_DAY                                                         = Journée du Cachemire
 holiday.description.KENNETH_KAUNDA_BIRTHDAY                                             = Anniversaire de Kenneth Kaunda
@@ -336,6 +341,7 @@ holiday.description.LOTU_O_TAMAITI                                              
 holiday.description.LOUIS_RIEL                                                          = Journée Louis Riel
 holiday.description.LUNAR_NEW_YEARS_DAY                                                 = Jour du nouvel an lunaire
 holiday.description.MADARAKA_DAY                                                        = Jour de Madaraka
+holiday.description.MADEIRA_DAY                                                         = Jour de la Région autonome de Madère et des communautés madériennes
 holiday.description.MADONNA_DELLA_SALUTE                                                = Fête de la Madonna della Salute
 holiday.description.MAHA_SHIVRATREE                                                     = Maha Shivaratree
 holiday.description.MAJORITY_RULE_DAY                                                   = Jour de la règle de la majorité
@@ -379,12 +385,14 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Journée nationale du service communautaire
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Journée nationale de la démocratie
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Journée Nationale de Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Jour de deuil national (mort de Néstor Kirchner)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Journée nationale de prière
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Journée nationale de prière et d'action de grâce
 holiday.description.NATIONAL_DAY_OF_THANKSGIVING                                        = Journée nationale d'action de grâce
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Journéenationale de sensibilisation aux zombies et aux Noirs
 holiday.description.NATIONAL_DECORATION_DAY                                             = Journée nationale de décoration
 holiday.description.NATIONAL_HEALTH_DAY                                                 = Journée nationale de la santé
+holiday.description.NATIONAL_HERITAGE_DAY                                               = Journée nationale du patrimoine
 holiday.description.NATIONAL_HEROES_AND_BENEFACTORS_DAY                                 = Journée des héros et bienfaiteurs nationaux
 holiday.description.NATIONAL_HEROES_AND_HEROINES_DAY                                    = Jour des héros et héroïnes nationaux
 holiday.description.NATIONAL_HEROES_DAY                                                 = Journée des héros nationaux
@@ -488,6 +496,7 @@ holiday.description.SABA_DAY                                                    
 holiday.description.SABA_SABA_DAY                                                       = Jour de Saba Saba
 holiday.description.SAINT_CLEMENT                                                       = St. Clement of Ohrid day
 holiday.description.SAINT_GEORGES_CAYE_DAY                                              = Journée de Saint George's Caye
+holiday.description.SAINT_JEAN_BAPTISTE_DAY                                             = Fête de la Saint-Jean-Baptiste
 holiday.description.SAO_TOME_DAY                                                        = Jour de Sao Tome
 holiday.description.SAINT_ISIDORE                                                       = Saint Isidore
 holiday.description.SAINT_MARONS                                                        = Fête de Saint Maron
@@ -514,6 +523,7 @@ holiday.description.SETTLER                                                     
 holiday.description.SEWARD                                                              = Seward's Day
 holiday.description.SG50_PUBLIC_HOLIDAY                                                 = Jour férié SG50
 holiday.description.SHACKLETON_DAY                                                      = Jour de Shackleton
+holiday.description.SHIVAJI_JAYANTI                                                     = Chhatrapati Shivaji Maharaj Jayanti
 holiday.description.SHOWA_DAY                                                           = Showa Day
 holiday.description.SIR_HAMMER_DEROBURT_DAY                                             = Jour de Sir Hammer DeRoburt
 holiday.description.SIR_SERETSE_KHAMA_DAY                                               = Jour du Sir Seretse Khama
@@ -548,11 +558,13 @@ holiday.description.ST_DEMETRIUS                                                
 holiday.description.ST_DEVOTA                                                           = Fête de Sainte Dévote
 holiday.description.ST_ELIJAH                                                           = St. Elijah's Day
 holiday.description.ST_FRANCIS_OF_ASSISI                                                = Jour de Saint François d’Assise
+holiday.description.ST_FRANCIS_XAVIER                                                   = Fête de Saint François Xavier
 holiday.description.ST_GEORGE                                                           = St. George Day
 holiday.description.ST_GERARD                                                           = Jour de Saint Gérard
 holiday.description.ST_GRATUS                                                           = Jour de Saint Grat
 holiday.description.ST_HELENA_DAY                                                       = Jour de Sainte-Hélène
 holiday.description.ST_JAMES                                                            = St. James Day
+holiday.description.ST_JANUARIUS                                                        = Fête de Saint Janvier
 holiday.description.ST_JOHN                                                             = St. John's Day
 holiday.description.ST_JOSEPH                                                           = St. Josephs day
 holiday.description.ST_JOSEPH_WORKER                                                    = Fête de Saint Joseph Ouvrier
@@ -573,6 +585,7 @@ holiday.description.ST_URSULA                                                   
 holiday.description.ST_VIGILIUS                                                         = Jour de Saint Vigile
 holiday.description.ST_VITALIAN                                                         = Jour de Saint Vitalien
 holiday.description.ST_VITUS                                                            = St. Vitus' Day
+holiday.description.SUBHAS_CHANDRA_BOSE_JAYANTI                                         = Subhas Chandra Bose Jayanti
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.SYRIAN_REVOLUTION_DAY                                               = Journée de la révolution syrienne
 holiday.description.TAKAI_COMMISSION_HOLIDAY                                            = Jour férié de la Commission Takai

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_nl.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_nl.properties
@@ -21,6 +21,7 @@ holiday.description.ALL_SAINTS                                                  
 holiday.description.ALL_SOULS                                                           = Allerzielen
 holiday.description.ALMUDENA_DAY                                                        = Dag van de Maagd van Almudena
 holiday.description.AMAZIGH_NEW_YEAR                                                    = Amazigh Nieuwjaar
+holiday.description.AMBEDKAR_JAYANTI                                                    = Ambedkar Jayanti
 holiday.description.AMERICAN_INDIAN_HERITAGE_DAY                                        = Dag van het Erfgoed van Amerikaanse Indianen
 holiday.description.AMERICAS_DAY                                                        = Amerika-dag
 holiday.description.ANCESTRY_DAY                                                        = Voorouderdag
@@ -53,6 +54,8 @@ holiday.description.AUGUST_BANK_HOLIDAY                                         
 holiday.description.AUGUST_FESTIVALS                                                    = Augustus Feestdagen
 holiday.description.AUGUST_MONDAY                                                       = Augustusmaandag
 holiday.description.AUGUST_THURSDAY                                                     = Augustusdonderdag
+holiday.description.AUTONOMY_DAY                                                        = Autonomiedag
+holiday.description.AZORES_DAY                                                          = Dag van de Autonome Regio de Azoren
 holiday.description.BANK_HOLIDAY                                                        = Bank feestdag
 holiday.description.BATTLE_BOYNE                                                        = Slag aan de Boyne
 holiday.description.BATTLE_DAY                                                          = Slagdag
@@ -212,6 +215,7 @@ holiday.description.FIRST_CHRISTMAS_DAY                                         
 holiday.description.FIRST_DAY_OF_JANUARY                                                = De eerste dag van januari
 holiday.description.FIRST_DAY_SUMMER                                                    = Eerste dag van de zomer
 holiday.description.FIRST_MARTYR                                                        = Eerste Martelaar
+holiday.description.FIRST_OCTAVE                                                        = Eerste Octaaf
 holiday.description.FIRST_WEEKDAY_AFTER_CHRISTMAS                                       = De eerste weekdag na Eerste Kerstdag
 holiday.description.FISHERMENS_DAY                                                      = Dag van de vissers
 holiday.description.FLAG_AND_UNIVERSITIES_DAY                                           = Dag van de Vlag en de Universiteiten
@@ -300,6 +304,7 @@ holiday.description.KADOOMENT_DAY                                               
 holiday.description.KALANIANAOLE                                                        = Dag van prins Jonah Kuhio Kalanianaole
 holiday.description.KAMEHAMEHA                                                          = Kamehameha Dag
 holiday.description.KAMUZU_BANDA                                                        = Verjaardag van President Kamuzu Banda
+holiday.description.KARNATAKA_RAJYOTSAVA                                                = Karnataka Rajyotsava
 holiday.description.KARUME_DAY                                                          = Karume Dag
 holiday.description.KASHMIR_DAY                                                         = Kasjmir-dag
 holiday.description.KENNETH_KAUNDA_BIRTHDAY                                             = Verjaardag van Kenneth Kaunda
@@ -336,6 +341,7 @@ holiday.description.LOTU_O_TAMAITI                                              
 holiday.description.LOUIS_RIEL                                                          = Louis Riel Dag
 holiday.description.LUNAR_NEW_YEARS_DAY                                                 = Lunar Nieuwjaarsdag
 holiday.description.MADARAKA_DAY                                                        = Madaraka-dag
+holiday.description.MADEIRA_DAY                                                         = Dag van de Autonome Regio Madeira en de Madeirese Gemeenschappen
 holiday.description.MADONNA_DELLA_SALUTE                                                = Feest van de Madonna della Salute
 holiday.description.MAHA_SHIVRATREE                                                     = Maha Shivaratree
 holiday.description.MAJORITY_RULE_DAY                                                   = Dag van de meerderheidsregel
@@ -379,12 +385,14 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Nationale Dag van Gemeenschapsdienst
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Nationale Dag van de Democratie
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Nationale dag van Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Nationale rouwdag (overlijden van Néstor Kirchner)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Nationale Gebedsdag
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Nationale dag van gebed en dankzegging
 holiday.description.NATIONAL_DAY_OF_THANKSGIVING                                        = Nationale Dankdag
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Nationale dag van Zumbi en zwarte bewustwording
 holiday.description.NATIONAL_DECORATION_DAY                                             = Nationale versieringsdag
 holiday.description.NATIONAL_HEALTH_DAY                                                 = Nationale Gezondheidsdag
+holiday.description.NATIONAL_HERITAGE_DAY                                               = Nationale Erfgoeddag
 holiday.description.NATIONAL_HEROES_AND_BENEFACTORS_DAY                                 = Dag van de nationale helden en weldoeners
 holiday.description.NATIONAL_HEROES_AND_HEROINES_DAY                                    = Dag van de nationale helden en heldinnen
 holiday.description.NATIONAL_HEROES_DAY                                                 = Nationale Heldendag
@@ -488,6 +496,7 @@ holiday.description.SABA_DAY                                                    
 holiday.description.SABA_SABA_DAY                                                       = Saba Saba Dag
 holiday.description.SAINT_CLEMENT                                                       = Saint Clement van Ohrid
 holiday.description.SAINT_GEORGES_CAYE_DAY                                              = Saint George's Caye-dag
+holiday.description.SAINT_JEAN_BAPTISTE_DAY                                             = Saint-Jean-Baptiste Dag
 holiday.description.SAO_TOME_DAY                                                        = Dag van Sao Tomé
 holiday.description.SAINT_ISIDORE                                                       = Sint Isidorus
 holiday.description.SAINT_MARONS                                                        = Feest van de Heilige Maron
@@ -514,6 +523,7 @@ holiday.description.SETTLER                                                     
 holiday.description.SEWARD                                                              = Seward's Dag
 holiday.description.SG50_PUBLIC_HOLIDAY                                                 = SG50 Feestdag
 holiday.description.SHACKLETON_DAY                                                      = Shackletondag
+holiday.description.SHIVAJI_JAYANTI                                                     = Chhatrapati Shivaji Maharaj Jayanti
 holiday.description.SHOWA_DAY                                                           = Showa dag
 holiday.description.SIR_HAMMER_DEROBURT_DAY                                             = Sir Hammer DeRoburtdag
 holiday.description.SIR_SERETSE_KHAMA_DAY                                               = Dag van Sir Seretse Khama
@@ -548,11 +558,13 @@ holiday.description.ST_DEMETRIUS                                                
 holiday.description.ST_DEVOTA                                                           = Dag van Heilige Dévote
 holiday.description.ST_ELIJAH                                                           = St.Elijah's dag
 holiday.description.ST_FRANCIS_OF_ASSISI                                                = Sint-Franciscus van Assisi-dag
+holiday.description.ST_FRANCIS_XAVIER                                                   = Feest van Sint-Franciscus Xaverius
 holiday.description.ST_GEORGE                                                           = St.George dag
 holiday.description.ST_GERARD                                                           = Sint-Gerardusdag
 holiday.description.ST_GRATUS                                                           = Sint-Gratusdag
 holiday.description.ST_HELENA_DAY                                                       = Sint-Helenadag
 holiday.description.ST_JAMES                                                            = St. James dag
+holiday.description.ST_JANUARIUS                                                        = Feest van Sint-Januarius
 holiday.description.ST_JOHN                                                             = St. John's dag
 holiday.description.ST_JOSEPH                                                           = St. Josephs dag
 holiday.description.ST_JOSEPH_WORKER                                                    = Feest van Sint-Jozef de Arbeider
@@ -573,6 +585,7 @@ holiday.description.ST_URSULA                                                   
 holiday.description.ST_VIGILIUS                                                         = Sint-Vigiliusdag
 holiday.description.ST_VITALIAN                                                         = Sint-Vitaliaandag
 holiday.description.ST_VITUS                                                            = St.Vitus' dag
+holiday.description.SUBHAS_CHANDRA_BOSE_JAYANTI                                         = Subhas Chandra Bose Jayanti
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.SYRIAN_REVOLUTION_DAY                                               = Dag van de Syrische Revolutie
 holiday.description.TAKAI_COMMISSION_HOLIDAY                                            = Takai-commissiedag
@@ -635,13 +648,11 @@ holiday.description.WHITE_SUNDAY                                                
 holiday.description.WILLIAM_TUBMAN_BIRTHDAY                                             = Verjaardag van William Tubman
 holiday.description.WINTER_MIDTERM_BANK_HOLIDAY                                         = Winter Midterm Vakantie
 holiday.description.WOMENS_DAY                                                          = Vrouwendag
-holiday.description.WORLD_CUP_BANK_HOLIDAY                                              = Feestdag voor het Wereldkampioenschap\
+holiday.description.WORLD_CUP_BANK_HOLIDAY                                              = Feestdag voor het Wereldkampioenschap
 holiday.description.WORLD_HEALTH_DAY                                                    = Wereldgezondheidsdag
 holiday.description.WORLD_RELIGION_DAY                                                  = Wereldreligiedag
-holiday.description.WORLD_RELIGION_DAY                                                  = Wereldreligiedag\
 holiday.description.WORLD_TEACHERS_DAY                                                  = Wereldlerarendag
 holiday.description.YAP_DAY                                                             = Yap-dag
-holiday.description.YEOM_E_TAKBEER                                                      = Youm-e-Takbeer
 holiday.description.YEOM_E_TAKBEER                                                      = Youm-e-Takbeer
 holiday.description.YOUTH                                                               = Jongerendag
 holiday.description.YOUTH_DAY                                                           = Jongerendag

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_pt.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_pt.properties
@@ -21,6 +21,7 @@ holiday.description.ALL_SAINTS                                                  
 holiday.description.ALL_SOULS                                                           = All Souls
 holiday.description.ALMUDENA_DAY                                                        = Dia da Virgem da Almudena
 holiday.description.AMAZIGH_NEW_YEAR                                                    = Ano Novo Amazigh
+holiday.description.AMBEDKAR_JAYANTI                                                    = Ambedkar Jayanti
 holiday.description.AMERICAN_INDIAN_HERITAGE_DAY                                        = Dia do Patrimônio dos Índios Americanos
 holiday.description.AMERICAS_DAY                                                        = Dia da América
 holiday.description.ANCESTRY_DAY                                                        = Dia da Ancestralidade
@@ -303,6 +304,7 @@ holiday.description.KADOOMENT_DAY                                               
 holiday.description.KALANIANAOLE                                                        = Prince Jonah Kuhio Kalanianaole Day
 holiday.description.KAMEHAMEHA                                                          = Kamehameha Day
 holiday.description.KAMUZU_BANDA                                                        = Aniversário do Presidente Kamuzu Banda
+holiday.description.KARNATAKA_RAJYOTSAVA                                                = Karnataka Rajyotsava
 holiday.description.KARUME_DAY                                                          = Dia de Karume
 holiday.description.KASHMIR_DAY                                                         = Dia do Caxemira
 holiday.description.KENNETH_KAUNDA_BIRTHDAY                                             = Aniversário de Kenneth Kaunda
@@ -383,12 +385,14 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Dia Nacional do Serviço Comunitário
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Dia Nacional da Democracia
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Dia Nacional de Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Dia de Luto Nacional (morte de Néstor Kirchner)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Dia Nacional de Oração
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Dia Nacional de Oração e Ação de Graças
 holiday.description.NATIONAL_DAY_OF_THANKSGIVING                                        = Dia Nacional de Ação de Graças
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Dia Nacional de Zumbi e da Consciência Negra
 holiday.description.NATIONAL_DECORATION_DAY                                             = Dia Nacional de Decoração
 holiday.description.NATIONAL_HEALTH_DAY                                                 = Dia Nacional da Saúde
+holiday.description.NATIONAL_HERITAGE_DAY                                               = Dia Nacional do Património
 holiday.description.NATIONAL_HEROES_AND_BENEFACTORS_DAY                                 = Dia dos Heróis e Benfeitores Nacionais
 holiday.description.NATIONAL_HEROES_AND_HEROINES_DAY                                    = Dia dos Heróis e Heroínas Nacionais
 holiday.description.NATIONAL_HEROES_DAY                                                 = Dia dos Heróis Nacionais
@@ -493,6 +497,7 @@ holiday.description.SABA_SABA_DAY                                               
 holiday.description.SAINT_CLEMENT                                                       = Dia de Saint Clement de Ohrid
 holiday.description.SAINT_GEORGES_CAYE_DAY                                              = Dia de Saint George's Caye
 holiday.description.SAINT_ISIDORE                                                       = São Isidro
+holiday.description.SAINT_JEAN_BAPTISTE_DAY                                             = Dia de São João Batista
 holiday.description.SAINT_MARONS                                                        = Festa de São Maron
 holiday.description.SAINT_OLAV_DAY                                                      = Dia de São Olavo
 holiday.description.SAINT_OLAV_EVE                                                      = Véspera de São Olavo
@@ -518,6 +523,7 @@ holiday.description.SETTLER                                                     
 holiday.description.SEWARD                                                              = Seward's Day
 holiday.description.SG50_PUBLIC_HOLIDAY                                                 = Feriado público do SG50
 holiday.description.SHACKLETON_DAY                                                      = Dia de Shackleton
+holiday.description.SHIVAJI_JAYANTI                                                     = Chhatrapati Shivaji Maharaj Jayanti
 holiday.description.SHOWA_DAY                                                           = Showa Day
 holiday.description.SIR_HAMMER_DEROBURT_DAY                                             = Dia de Sir Hammer DeRoburt
 holiday.description.SIR_SERETSE_KHAMA_DAY                                               = Dia de Sir Seretse Khama
@@ -552,11 +558,13 @@ holiday.description.ST_DEMETRIUS                                                
 holiday.description.ST_DEVOTA                                                           = Dia de Santa Devota
 holiday.description.ST_ELIJAH                                                           = Dia de St. Elijah
 holiday.description.ST_FRANCIS_OF_ASSISI                                                = Dia de São Francisco de Assis
+holiday.description.ST_FRANCIS_XAVIER                                                   = Festa de São Francisco Xavier
 holiday.description.ST_GEORGE                                                           = Dia de São Jorge
 holiday.description.ST_GERARD                                                           = Dia de São Gerardo
 holiday.description.ST_GRATUS                                                           = Dia de São Grato
 holiday.description.ST_HELENA_DAY                                                       = Dia de Santa Helena
 holiday.description.ST_JAMES                                                            = Dia de St. James
+holiday.description.ST_JANUARIUS                                                        = Festa de São Januário
 holiday.description.ST_JOHN                                                             = Dia de São João
 holiday.description.ST_JOSEPH                                                           = Dia de St. Josephs
 holiday.description.ST_JOSEPH_WORKER                                                    = Festa de São José Operário
@@ -577,6 +585,7 @@ holiday.description.ST_URSULA                                                   
 holiday.description.ST_VIGILIUS                                                         = Dia de São Vigílio
 holiday.description.ST_VITALIAN                                                         = Dia de São Vitaliano
 holiday.description.ST_VITUS                                                            = Dia de St. Vitus
+holiday.description.SUBHAS_CHANDRA_BOSE_JAYANTI                                         = Subhas Chandra Bose Jayanti
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.SYRIAN_REVOLUTION_DAY                                               = Dia da Revolução Síria
 holiday.description.TAKAI_COMMISSION_HOLIDAY                                            = Feriado da Comissão Takai

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_sv.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_sv.properties
@@ -21,6 +21,7 @@ holiday.description.ALL_SAINTS                                                  
 holiday.description.ALL_SOULS                                                           = All Souls
 holiday.description.ALMUDENA_DAY                                                        = Jungfrun av Almudena-dagen
 holiday.description.AMAZIGH_NEW_YEAR                                                    = Amazighs nyår
+holiday.description.AMBEDKAR_JAYANTI                                                    = Ambedkar Jayanti
 holiday.description.AMERICAN_INDIAN_HERITAGE_DAY                                        = Dag för Amerikanska Indianers Kulturarv
 holiday.description.AMERICAS_DAY                                                        = Amerikas dag
 holiday.description.ANCESTRY_DAY                                                        = Släktens dag
@@ -53,6 +54,8 @@ holiday.description.AUGUST_BANK_HOLIDAY                                         
 holiday.description.AUGUST_FESTIVALS                                                    = Augustifestiviteterna
 holiday.description.AUGUST_MONDAY                                                       = Augustimåndag
 holiday.description.AUGUST_THURSDAY                                                     = Augustitorsdag
+holiday.description.AUTONOMY_DAY                                                        = Autonomidagen
+holiday.description.AZORES_DAY                                                          = Azorernas autonoma regions dag
 holiday.description.BANK_HOLIDAY                                                        = Bankhelg
 holiday.description.BATTLE_BOYNE                                                        = Battle of the Boyne
 holiday.description.BATTLE_DAY                                                          = Slagsmåletdagen
@@ -74,6 +77,7 @@ holiday.description.BOXING_DAY                                                  
 holiday.description.BOYACA                                                              = Battle of Boyacá
 holiday.description.BRIDGING_HOLIDAY                                                    = Bridging Holiday
 holiday.description.BROOKLY_QUEENS                                                      = Brooklyn-Queens Day
+holiday.description.BUCKLYS_UPRISING_DAY                                                = Buckleys upprorsdag
 holiday.description.BUNKER_HILL                                                         = Bunker Hill Day
 holiday.description.CABRINI_DAY                                                         = Cabrini-dagen
 holiday.description.CANADA_DAY                                                          = Kanadas dag
@@ -84,6 +88,7 @@ holiday.description.CANTERBURY_ANNIVERSARY                                      
 holiday.description.CANTERBURY_SOUTH_ANNIVERSARY                                        = South Canterbury Anniversary
 holiday.description.CARABOBO                                                            = Battle of Carabobo
 holiday.description.CARICOM_DAY                                                         = CARICOM-dagen
+holiday.description.CARNIVAL_DAY                                                        = Karnevalsdagen
 holiday.description.CARNIVAL_MONDAY                                                     = Carnival måndag
 holiday.description.CARNIVAL_TUESDAY                                                    = Carnival tisdag
 holiday.description.CARTAGENA                                                           = Independence of Cartagena
@@ -124,6 +129,7 @@ holiday.description.COPTIC_CHRISTMAS                                            
 holiday.description.COPTIC_EASTER                                                       = Kopptisk påsk
 holiday.description.CORN_RIOTS_ANNIVERSARY                                              = Årsdagen av majskravallerna
 holiday.description.CROWN_PRINCE_BIRTHDAY                                               = Kronprinsens födelsedag
+holiday.description.CULTURAMA_DAY                                                       = Culturama-dagen
 holiday.description.CULTURE_DAY                                                         = Culture Day
 holiday.description.CURRENCY_CHANGE_DAY                                                 = Valutaväxlingsdag
 holiday.description.CURACAO_DAY                                                         = Curaçaos dag
@@ -209,6 +215,7 @@ holiday.description.FIRST_CHRISTMAS_DAY                                         
 holiday.description.FIRST_DAY_OF_JANUARY                                                = Den första dagen i januari
 holiday.description.FIRST_DAY_SUMMER                                                    = First Day of Summer
 holiday.description.FIRST_MARTYR                                                        = Första martyren
+holiday.description.FIRST_OCTAVE                                                        = Första oktaven
 holiday.description.FIRST_WEEKDAY_AFTER_CHRISTMAS                                       = Den första vardagen efter juldagen
 holiday.description.FISHERMENS_DAY                                                      = Fiskarnas dag
 holiday.description.FLAG_AND_UNIVERSITIES_DAY                                           = Flaggdagen och universitetsdagen
@@ -297,6 +304,7 @@ holiday.description.KADOOMENT_DAY                                               
 holiday.description.KALANIANAOLE                                                        = Prince Jonah Kuhio Kalanianaole Day
 holiday.description.KAMEHAMEHA                                                          = Kamehameha Day
 holiday.description.KAMUZU_BANDA                                                        = Presidenten Kamuzu Bandas födelsedag
+holiday.description.KARNATAKA_RAJYOTSAVA                                                = Karnataka Rajyotsava
 holiday.description.KARUME_DAY                                                          = Karume Day
 holiday.description.KASHMIR_DAY                                                         = Kashmir-dagen
 holiday.description.KENNETH_KAUNDA_BIRTHDAY                                             = Kenneth Kaundas födelsedag
@@ -333,6 +341,7 @@ holiday.description.LOTU_O_TAMAITI                                              
 holiday.description.LOUIS_RIEL                                                          = Louis Riel-dagen
 holiday.description.LUNAR_NEW_YEARS_DAY                                                 = Lunarnyårsdagen
 holiday.description.MADARAKA_DAY                                                        = Madaraka-dagen
+holiday.description.MADEIRA_DAY                                                         = Dagen för den autonoma regionen Madeira och de madeirska samhällena
 holiday.description.MADONNA_DELLA_SALUTE                                                = Madonna della Salute-festen
 holiday.description.MAHA_SHIVRATREE                                                     = Maha Shivaratree
 holiday.description.MAJORITY_RULE_DAY                                                   = Majoritetsreglernas dag
@@ -376,12 +385,14 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Nationell dag för samhällstjänst
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Demokratins nationaldag
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Nationella dagen för Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Nationell sorgedag (Néstor Kirchners död)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Nationella bönedagen
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Nationella böne- och tacksägelsedagen
 holiday.description.NATIONAL_DAY_OF_THANKSGIVING                                        = Nationell tacksägelsedag
 holiday.description.NATIONAL_DAY_OF_ZUMBI_AND_BLACK_AWARENESS                           = Nationella dagen för Zumbi och svart medvetenhet
 holiday.description.NATIONAL_DECORATION_DAY                                             = Nationella dekorationens dag
 holiday.description.NATIONAL_HEALTH_DAY                                                 = Nationella hälsodagen
+holiday.description.NATIONAL_HERITAGE_DAY                                               = Nationella kulturarvsdagen
 holiday.description.NATIONAL_HEROES_AND_BENEFACTORS_DAY                                 = Nationella hjältars och välgörares dag
 holiday.description.NATIONAL_HEROES_AND_HEROINES_DAY                                    = Nationella hjältars och hjältinnors dag
 holiday.description.NATIONAL_HEROES_DAY                                                 = Nationella hjältarnas dag
@@ -486,6 +497,7 @@ holiday.description.SABA_SABA_DAY                                               
 holiday.description.SAINT_CLEMENT                                                       = Saint Clement of Ohrid day
 holiday.description.SAINT_GEORGES_CAYE_DAY                                              = Saint George's Caye-dagen
 holiday.description.SAINT_ISIDORE                                                       = Sankt Isidor
+holiday.description.SAINT_JEAN_BAPTISTE_DAY                                             = Sankt-Jean-Baptiste-dagen
 holiday.description.SAINT_MARONS                                                        = Helige Marons fest
 holiday.description.SAINT_OLAV_DAY                                                      = Olofsdagen
 holiday.description.SAINT_OLAV_EVE                                                      = Olofsmässoafton
@@ -511,6 +523,7 @@ holiday.description.SETTLER                                                     
 holiday.description.SEWARD                                                              = Seward's Day
 holiday.description.SG50_PUBLIC_HOLIDAY                                                 = SG50 allmän helgdag
 holiday.description.SHACKLETON_DAY                                                      = Shackletondagen
+holiday.description.SHIVAJI_JAYANTI                                                     = Chhatrapati Shivaji Maharaj Jayanti
 holiday.description.SHOWA_DAY                                                           = Showa Day
 holiday.description.SIR_HAMMER_DEROBURT_DAY                                             = Sir Hammer DeRoburt-dagen
 holiday.description.SIR_SERETSE_KHAMA_DAY                                               = Sir Seretse Khama-dagen
@@ -545,11 +558,13 @@ holiday.description.ST_DEMETRIUS                                                
 holiday.description.ST_DEVOTA                                                           = Sankt Devotas Dag
 holiday.description.ST_ELIJAH                                                           = St.Elijah's Day
 holiday.description.ST_FRANCIS_OF_ASSISI                                                = Sankte Franciskus dag
+holiday.description.ST_FRANCIS_XAVIER                                                   = Sankt Franciskus Xaverius fest
 holiday.description.ST_GEORGE                                                           = St.George Day
 holiday.description.ST_GERARD                                                           = Sankt Gerard dag
 holiday.description.ST_GRATUS                                                           = Sankt Gratus dag
 holiday.description.ST_HELENA_DAY                                                       = Sankta Helena-dagen
 holiday.description.ST_JAMES                                                            = St. James Day
+holiday.description.ST_JANUARIUS                                                        = Sankt Januarius fest
 holiday.description.ST_JOHN                                                             = St. John's Day
 holiday.description.ST_JOSEPH                                                           = St. Josephs day
 holiday.description.ST_JOSEPH_WORKER                                                    = Sankt Josef arbetarens dag
@@ -570,6 +585,7 @@ holiday.description.ST_URSULA                                                   
 holiday.description.ST_VIGILIUS                                                         = Sankt Vigilius dag
 holiday.description.ST_VITALIAN                                                         = Sankt Vitalianus dag
 holiday.description.ST_VITUS                                                            = St.Vitus' Day
+holiday.description.SUBHAS_CHANDRA_BOSE_JAYANTI                                         = Subhas Chandra Bose Jayanti
 holiday.description.SUMMER_BANK_HOLIDAY                                                 = Summer Bank Holiday
 holiday.description.SYRIAN_REVOLUTION_DAY                                               = Syriska revolutionens dag
 holiday.description.TAKAI_COMMISSION_HOLIDAY                                            = Takai-kommissionens helgdag

--- a/jollyday-core/src/main/resources/holidays/Holidays_ar.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_ar.xml
@@ -19,7 +19,8 @@
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
-    <Fixed month="OCTOBER" day="27" validFrom="2010" validTo="2010"/>
+    <Fixed month="OCTOBER" day="27" validFrom="2010" validTo="2010"
+           descriptionPropertiesKey="NATIONAL_DAY_OF_MOURNING_KIRCHNER" localizedType="OBSERVANCE"/>
     <Fixed month="DECEMBER" day="8" descriptionPropertiesKey="IMMACULATE_CONCEPTION"/>
     <Fixed month="DECEMBER" day="24" descriptionPropertiesKey="CHRISTMAS_EVE"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>

--- a/jollyday-core/src/main/resources/holidays/Holidays_es.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_es.xml
@@ -145,7 +145,7 @@
   <SubConfigurations hierarchy="ex" description="Extremadura">
     <Holidays>
       <Fixed month="FEBRUARY" day="21" validFrom="2023" validTo="2023"
-             descriptionPropertiesKey="CARNIVAL"/> <!--Carnival Tuesday-->
+             descriptionPropertiesKey="CARNIVAL_TUESDAY"/> <!--Carnival Tuesday-->
       <Fixed month="MARCH" day="19" validFrom="2000" validTo="2014" descriptionPropertiesKey="ST_JOSEPH">
         <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
       </Fixed>

--- a/jollyday-core/src/main/resources/holidays/Holidays_gi.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_gi.xml
@@ -33,7 +33,7 @@
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
     </Fixed>
 
-    <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2022" descriptionPropertiesKey="WINTER_MID_TERM_BANK_HOLIDAY"/>
+    <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" validFrom="2022" descriptionPropertiesKey="WINTER_MIDTERM_BANK_HOLIDAY"/>
     <FixedWeekday which="LAST" weekday="MONDAY" month="MAY" validFrom="1971" descriptionPropertiesKey="SPRING_BANK_HOLIDAY"/>
     <FixedWeekday which="LAST" weekday="MONDAY" month="AUGUST" validFrom="1971" descriptionPropertiesKey="SUMMER_BANK_HOLIDAY"/>
 

--- a/jollyday-core/src/main/resources/holidays/Holidays_gq.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_gq.xml
@@ -14,7 +14,7 @@
     <Fixed month="JUNE" day="5" descriptionPropertiesKey="PRESIDENTS_DAY">
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
-    <Fixed month="AUGUST" day="3" descriptionPropertiesKey="FREEDOM_DAY">
+    <Fixed month="AUGUST" day="3" descriptionPropertiesKey="FREEDOM">
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
     <Fixed month="AUGUST" day="15" descriptionPropertiesKey="CONSTITUTION_DAY">

--- a/jollyday-core/src/main/resources/holidays/Holidays_in.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_in.xml
@@ -31,7 +31,7 @@
 
   <SubConfigurations hierarchy="ap" description="Andhra Pradesh">
     <Holidays>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
@@ -63,7 +63,7 @@
   <SubConfigurations hierarchy="br" description="Bihār">
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
@@ -74,7 +74,7 @@
 
   <SubConfigurations hierarchy="ch" description="Chandīgarh">
     <Holidays>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
@@ -114,7 +114,7 @@
   <SubConfigurations hierarchy="ga" description="Goa">
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
-      <Fixed month="DECEMBER" day="3"/>
+      <Fixed month="DECEMBER" day="3" descriptionPropertiesKey="ST_FRANCIS_XAVIER"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
@@ -123,7 +123,7 @@
 
   <SubConfigurations hierarchy="gj" description="Gujarāt">
     <Holidays>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <IslamicHoliday type="ID_UL_ADHA"/>
     </Holidays>
@@ -131,7 +131,7 @@
 
   <SubConfigurations hierarchy="hr" description="Haryāna">
     <Holidays>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
     </Holidays>
   </SubConfigurations>
@@ -145,7 +145,7 @@
 
   <SubConfigurations hierarchy="jk" description="Jammu and Kashmīr">
     <Holidays>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="ID_UL_ADHA"/>
@@ -163,8 +163,8 @@
   <SubConfigurations hierarchy="ka" description="Karnātaka">
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
-      <Fixed month="APRIL" day="14"/>
-      <Fixed month="NOVEMBER" day="1"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
+      <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="KARNATAKA_RAJYOTSAVA"/>
       <Fixed month="NOVEMBER" day="5"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
@@ -178,7 +178,7 @@
   <SubConfigurations hierarchy="kl" description="Kerala">
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
@@ -211,8 +211,8 @@
   <SubConfigurations hierarchy="mh" description="Mahārāshtra">
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
-      <Fixed month="APRIL" day="14"/>
-      <Fixed month="FEBRUARY" day="19"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
+      <Fixed month="FEBRUARY" day="19" descriptionPropertiesKey="SHIVAJI_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
@@ -263,7 +263,7 @@
 
   <SubConfigurations hierarchy="od" description="Odisha">
     <Holidays>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="ID_UL_ADHA"/>
@@ -273,7 +273,7 @@
   <SubConfigurations hierarchy="py" description="Puducherry">
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
@@ -300,7 +300,7 @@
 
   <SubConfigurations hierarchy="sk" description="Sikkim">
     <Holidays>
-      <Fixed month="MAY" day="16"/>
+      <Fixed month="MAY" day="16" descriptionPropertiesKey="STATEHOOD"/>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
@@ -311,7 +311,7 @@
   <SubConfigurations hierarchy="tn" description="Tamil Nādu">
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
@@ -329,7 +329,7 @@
   <SubConfigurations hierarchy="tr" description="Tripura">
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
-      <Fixed month="JANUARY" day="23"/>
+      <Fixed month="JANUARY" day="23" descriptionPropertiesKey="SUBHAS_CHANDRA_BOSE_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <IslamicHoliday type="ID_UL_ADHA"/>
     </Holidays>
@@ -337,7 +337,7 @@
 
   <SubConfigurations hierarchy="up" description="Uttar Pradesh">
     <Holidays>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="MARCH" day="15"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
@@ -350,7 +350,7 @@
 
   <SubConfigurations hierarchy="uk" description="Uttarākhand">
     <Holidays>
-      <Fixed month="APRIL" day="14"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
@@ -363,7 +363,7 @@
   <SubConfigurations hierarchy="wb" description="West Bengal">
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
-      <Fixed month="JANUARY" day="23"/>
+      <Fixed month="JANUARY" day="23" descriptionPropertiesKey="SUBHAS_CHANDRA_BOSE_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>

--- a/jollyday-core/src/main/resources/holidays/Holidays_lu.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_lu.xml
@@ -31,7 +31,7 @@
 
     <SubConfigurations hierarchy="clu" description="City of Luxembourg">
       <Holidays>
-        <Fixed month="FEBRUARY" day="15" descriptionPropertiesKey="CARNIVAL"/>
+        <Fixed month="FEBRUARY" day="15" descriptionPropertiesKey="CARNIVAL_DAY"/>
       </Holidays>
     </SubConfigurations>
   </SubConfigurations>

--- a/jollyday-core/src/main/resources/holidays/Holidays_mw.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_mw.xml
@@ -23,7 +23,7 @@
     <Fixed month="JULY" day="6" descriptionPropertiesKey="INDEPENDENCE_DAY">
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
-    <Fixed month="OCTOBER" day="15" descriptionPropertiesKey="MOTHERS">
+    <Fixed month="OCTOBER" day="15" descriptionPropertiesKey="MOTHERS_DAY">
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS">

--- a/jollyday-core/src/main/resources/holidays/Holidays_pk.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_pk.xml
@@ -11,7 +11,7 @@
     <Fixed month="MAY" day="28" descriptionPropertiesKey="YEOM_E_TAKBEER"/>
     <Fixed month="AUGUST" day="14" descriptionPropertiesKey="INDEPENDENCE_DAY"/>
     <Fixed month="NOVEMBER" day="9" descriptionPropertiesKey="IQBAL_DAY"/>
-    <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="QUAIDE_AZAM_DAY"/>
+    <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="QUAID_E_AZAM_DAY"/>
     <IslamicHoliday type="TASUA" descriptionPropertiesKey="islamic.ASCHURA"/>
     <IslamicHoliday type="ASCHURA"/>
     <IslamicHoliday type="MAWLID_AN_NABI"/>

--- a/jollyday-core/src/main/resources/holidays/Holidays_tm.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_tm.xml
@@ -11,7 +11,7 @@
     <Fixed month="MARCH" day="22" descriptionPropertiesKey="NOWRUZ"/>
     <Fixed month="MAY" day="18" descriptionPropertiesKey="STATE_FLAG_AND_CONSTITUTION_DAY"/>
     <Fixed month="SEPTEMBER" day="27" descriptionPropertiesKey="INDEPENDENCE_DAY"/>
-    <Fixed month="OCTOBER" day="6" descriptionPropertiesKey="DAY_OF_REMEMBRANCE"/>
+    <Fixed month="OCTOBER" day="6" descriptionPropertiesKey="DAY_OF_REMEMBRANCE_TM"/>
     <Fixed month="DECEMBER" day="12" descriptionPropertiesKey="DAY_OF_NEUTRALITY"/>
     <IslamicHoliday type="ID_AL_FITR"/>
     <IslamicHoliday type="ID_UL_ADHA"/>

--- a/jollyday-core/src/main/resources/holidays/Holidays_xk.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_xk.xml
@@ -15,7 +15,7 @@
 
     <Fixed month="APRIL" day="23" descriptionPropertiesKey="DAY_OF_THE_TURKS"/>
 
-    <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOR_DAY"/>
+    <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
     <Fixed month="MAY" day="6" descriptionPropertiesKey="DAY_OF_THE_GORANS"/>
     <Fixed month="MAY" day="9" descriptionPropertiesKey="EUROPE_DAY"/>
 

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayESTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayESTest.java
@@ -217,7 +217,7 @@ class HolidayESTest {
       // Ceuta
 
       // Extremadura
-      .hasFixedHoliday("CARNIVAL", FEBRUARY, 21)
+      .hasFixedHoliday("CARNIVAL_TUESDAY", FEBRUARY, 21)
         .inSubdivision("ex")
         .validBetween(Year.of(2023), Year.of(2023))
       .and()

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayGQTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayGQTest.java
@@ -21,7 +21,7 @@ class HolidayGQTest {
       .hasFixedHoliday("NEW_YEAR", JANUARY, 1).canBeMovedFrom(SUNDAY, MONDAY).and()
       .hasFixedHoliday("LABOUR_DAY", MAY, 1).canBeMovedFrom(SUNDAY, MONDAY).and()
       .hasFixedHoliday("PRESIDENTS_DAY", JUNE, 5).canBeMovedFrom(SUNDAY, MONDAY).and()
-      .hasFixedHoliday("FREEDOM_DAY", AUGUST, 3).canBeMovedFrom(SUNDAY, MONDAY).and()
+      .hasFixedHoliday("FREEDOM", AUGUST, 3).canBeMovedFrom(SUNDAY, MONDAY).and()
       .hasFixedHoliday("CONSTITUTION_DAY", AUGUST, 15).canBeMovedFrom(SUNDAY, MONDAY).and()
       .hasFixedHoliday("INDEPENDENCE_DAY", OCTOBER, 12).canBeMovedFrom(SUNDAY, MONDAY).and()
       .hasFixedHoliday("IMMACULATE_CONCEPTION", DECEMBER, 8).canBeMovedFrom(SUNDAY, MONDAY).and()

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayLUTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayLUTest.java
@@ -6,6 +6,7 @@ import static de.focus_shift.jollyday.core.HolidayCalendar.LUXEMBOURG;
 import static de.focus_shift.jollyday.tests.CalendarCheckerApi.assertFor;
 import static java.time.Month.AUGUST;
 import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
 import static java.time.Month.JANUARY;
 import static java.time.Month.JUNE;
 import static java.time.Month.MAY;
@@ -20,7 +21,7 @@ class HolidayLUTest {
       .hasFixedHoliday("NEW_YEAR", JANUARY, 1).and()
       .hasFixedHoliday("LABOUR_DAY", MAY, 1).and()
       .hasFixedHoliday("EUROPE_DAY", MAY, 9)
-        .validBetween(of(2019), of(2500)).and()
+      .validBetween(of(2019), of(2500)).and()
       .hasFixedHoliday("NATIONAL_DAY", JUNE, 23).and()
       .hasFixedHoliday("ASSUMPTION_DAY", AUGUST, 15).and()
       .hasFixedHoliday("ALL_SAINTS", NOVEMBER, 1).and()
@@ -28,7 +29,8 @@ class HolidayLUTest {
       .hasFixedHoliday("STEPHENS", DECEMBER, 26).and()
       .hasChristianHoliday("EASTER_MONDAY").and()
       .hasChristianHoliday("ASCENSION_DAY").and()
-      .hasChristianHoliday("WHIT_MONDAY")
+      .hasChristianHoliday("WHIT_MONDAY").and()
+      .hasFixedHoliday("CARNIVAL_DAY", FEBRUARY, 15).inSubdivision("lu", "clu")
       .check();
   }
 }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayMWTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayMWTest.java
@@ -29,7 +29,7 @@ class HolidayMWTest {
       .hasFixedHoliday("LABOUR_DAY", MAY, 1).canBeMovedFrom(SUNDAY, MONDAY).validBetween(YEAR_FROM, YEAR_TO).and()
       .hasFixedHoliday("KAMUZU_BANDA", MAY, 14).canBeMovedFrom(SUNDAY, MONDAY).validBetween(YEAR_FROM, YEAR_TO).and()
       .hasFixedHoliday("INDEPENDENCE_DAY", JULY, 6).canBeMovedFrom(SUNDAY, MONDAY).validBetween(YEAR_FROM, YEAR_TO).and()
-      .hasFixedHoliday("MOTHERS", OCTOBER, 15).canBeMovedFrom(SUNDAY, MONDAY).validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("MOTHERS_DAY", OCTOBER, 15).canBeMovedFrom(SUNDAY, MONDAY).validBetween(YEAR_FROM, YEAR_TO).and()
       .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).canBeMovedFrom(SUNDAY, MONDAY).validBetween(YEAR_FROM, YEAR_TO).and()
       .hasFixedHoliday("BOXING_DAY", DECEMBER, 26).canBeMovedFrom(SUNDAY, MONDAY).validBetween(YEAR_FROM, YEAR_TO).and()
       .hasChristianHoliday("GOOD_FRIDAY").validBetween(YEAR_FROM, YEAR_TO).and()

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayPKTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayPKTest.java
@@ -22,7 +22,7 @@ class HolidayPKTest {
       .hasFixedHoliday("YEOM_E_TAKBEER", MAY, 28).validBetween(YEAR_FROM, YEAR_TO).and()
       .hasFixedHoliday("INDEPENDENCE_DAY", AUGUST, 14).validBetween(YEAR_FROM, YEAR_TO).and()
       .hasFixedHoliday("IQBAL_DAY", NOVEMBER, 9).validBetween(YEAR_FROM, YEAR_TO).and()
-      .hasFixedHoliday("QUAIDE_AZAM_DAY", DECEMBER, 25).validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("QUAID_E_AZAM_DAY", DECEMBER, 25).validBetween(YEAR_FROM, YEAR_TO).and()
       .hasIslamicHoliday("ASCHURA").validBetween(YEAR_FROM, YEAR_TO).and()
       .hasIslamicHoliday("MAWLID_AN_NABI").validBetween(YEAR_FROM, YEAR_TO).and()
       .hasIslamicHoliday("ID_AL_FITR").validBetween(YEAR_FROM, YEAR_TO).and()

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayTMTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayTMTest.java
@@ -39,7 +39,7 @@ class HolidayTMTest {
       .hasFixedHoliday("INDEPENDENCE_DAY", SEPTEMBER, 27)
         .validBetween(YEAR_FROM, YEAR_TO)
       .and()
-      .hasFixedHoliday("DAY_OF_REMEMBRANCE", OCTOBER, 6)
+      .hasFixedHoliday("DAY_OF_REMEMBRANCE_TM", OCTOBER, 6)
         .validBetween(YEAR_FROM, YEAR_TO)
       .and()
       .hasFixedHoliday("DAY_OF_NEUTRALITY", DECEMBER, 12)

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayXKTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayXKTest.java
@@ -25,7 +25,7 @@ class HolidayXKTest {
       .hasFixedHoliday("VETERANS_DAY", MARCH, 6).and()
       .hasFixedHoliday("ROMA_DAY", MARCH, 8).and()
       .hasFixedHoliday("DAY_OF_THE_TURKS", APRIL, 23).and()
-      .hasFixedHoliday("LABOR_DAY", MAY, 1).and()
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).and()
       .hasFixedHoliday("DAY_OF_THE_GORANS", MAY, 6).and()
       .hasFixedHoliday("EUROPE_DAY", MAY, 9).and()
       .hasFixedHoliday("DAY_OF_PEACE", JUNE, 12).and()


### PR DESCRIPTION
## Summary
- `HolidayDescriptionTest` only checked that keys appearing in a locale bundle also exist in the root bundle - it never checked the reverse, and never checked that a key an XML file actually references exists anywhere at all. `ResourceUtil.getDescription` silently returns the literal string `"undefined"` for a missing key, so a typo or omitted attribute ships as broken user-facing text with a fully green build.
- Adds a test that drives every bundled calendar (including subdivisions) through the real `HolidayManager` across a decade of years, collects every properties key actually used, and asserts each one is present in every locale bundle.

Running this against the current data surfaced real, currently-shipping bugs rather than a hypothetical gap:

- ~40 `Fixed` holidays (India, Argentina, South Africa) had no `descriptionPropertiesKey` attribute at all and rendered as the literal string `"undefined"`. Researched and added correct keys/descriptions for all but three: Karnataka Nov 5, Uttar Pradesh Mar 15, and South Africa Jul 10 (1961-1974) could not be verified against any credible source, so they're deliberately left unresolved and excluded via a documented allowlist in the test rather than guessed.
- Several holidays referenced a key that was a near-miss typo of an already fully-translated key (`DAY_OF_REMEMBRANCE` vs `DAY_OF_REMEMBRANCE_TM`, `LABOR_DAY` vs `LABOUR_DAY`, `MOTHERS` vs `MOTHERS_DAY`, `QUAIDE_AZAM_DAY` vs `QUAID_E_AZAM_DAY`, `WINTER_MID_TERM_BANK_HOLIDAY` vs `WINTER_MIDTERM_BANK_HOLIDAY`, `FREEDOM_DAY` vs `FREEDOM`, bare `CARNIVAL` vs `christian.CARNIVAL`) - repointed the XML at the correct existing key instead of adding duplicate translations.
- `holiday_descriptions_nl.properties` had a stray trailing backslash turning `WORLD_CUP_BANK_HOLIDAY`'s value into a line-continuation that silently swallowed the `WORLD_HEALTH_DAY` entry, and a duplicate `WORLD_RELIGION_DAY` line did the same to `WORLD_TEACHERS_DAY` - both keys were effectively absent from the Dutch bundle. Removed the continuations and the duplicate.
- Filled genuine translation gaps for `AUTONOMY_DAY`/`AZORES_DAY`/`FIRST_OCTAVE`/`MADEIRA_DAY` (el/fr/nl/sv) and `BUCKLYS_UPRISING_DAY`/`CARNIVAL_DAY`/`CULTURAMA_DAY` (sv).

## Test plan
- [x] New test `ensureEveryReferencedHolidayDescriptionKeyIsTranslatedInEveryLocale` - confirmed it fails against the un-patched data (real missing/mismatched keys), then confirmed it passes after each fix
- [x] Updated the 6 existing per-country tests (`HolidayESTest`, `HolidayGQTest`, `HolidayMWTest`, `HolidayPKTest`, `HolidayTMTest`, `HolidayXKTest`) whose assertions had hard-coded the old, buggy key names
- [x] Full `jollyday-core`, `jollyday-jaxb`, `jollyday-jackson`, `jollyday-tests` suites pass