### PR TITLE
Return an unmodifiable set from getHolidays to protect the shared cache

### DIFF
--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/DefaultHolidayManager.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/DefaultHolidayManager.java
@@ -109,7 +109,7 @@ public class DefaultHolidayManager extends HolidayManager {
       }
     };
 
-    return holidayCache.get(holidayValueHandler);
+    return Set.copyOf(holidayCache.get(holidayValueHandler));
   }
 
   /**

--- a/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/JapaneseBridgingHolidayManager.java
+++ b/jollyday-core/src/main/java/de/focus_shift/jollyday/core/impl/JapaneseBridgingHolidayManager.java
@@ -42,7 +42,8 @@ public class JapaneseBridgingHolidayManager extends DefaultHolidayManager {
       }
     }
 
-    holidays.addAll(bridgingHolidays);
-    return holidays;
+    final Set<Holiday> allHolidays = new HashSet<>(holidays);
+    allHolidays.addAll(bridgingHolidays);
+    return Set.copyOf(allHolidays);
   }
 }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/DefaultHolidayManagerTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/DefaultHolidayManagerTest.java
@@ -85,6 +85,20 @@ class DefaultHolidayManagerTest {
   }
 
   @Test
+  void ensureGetHolidaysReturnsAnUnmodifiableSetSoCallersCannotCorruptTheSharedCache() {
+    final HolidayManager sut = HolidayManager.getInstance(create("test"));
+    final Year year = Year.of(2010);
+
+    final Set<Holiday> holidays = sut.getHolidays(year);
+    assertThat(holidays).isNotEmpty();
+
+    assertThatThrownBy(holidays::clear).isInstanceOf(UnsupportedOperationException.class);
+
+    // a second call must still see the full, uncorrupted set of holidays
+    assertThat(sut.getHolidays(year)).isEqualTo(holidays);
+  }
+
+  @Test
   void ensureIsHolidayMethodReturnsTrueFalseForCalendarChronology() {
     final HolidayManager sut = HolidayManager.getInstance(create("test"));
 


### PR DESCRIPTION
DefaultHolidayManager.getHolidays(Year, args) returned the exact Set<Holiday> instance stored in its per-(year,args) cache. Nothing about the method's contract signalled that the returned set was a live reference into shared, cached state rather than the caller's own copy - so any caller mutating it would silently corrupt what every future call for that same year/args would see.

JapaneseBridgingHolidayManager already relied on this: it called super.getHolidays(...) and mutated the result in place via holidays.addAll(bridgingHolidays). That's harmless today only because the bridging computation is deterministic and purely additive, so repeating it is a no-op - but nothing stopped a future subclass or caller from doing something less benign.

Make the contract explicit: getHolidays now returns Set.copyOf(...), an immutable set, so mutation attempts fail fast instead of silently corrupting the cache. Updated JapaneseBridgingHolidayManager to build its own copy instead of mutating the (now immutable) set it gets from its superclass.

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
