### PR TITLE
Improve NYSE, NYSE Euronext, TARGET and TARGET2-Securities holiday ca…

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,20 @@ To access the public holidays of a subdivision of a country, e.g. Baden-Württem
 | Subdivisions ([ISO 3166-2])    | Yes       |
 | City Holiday                   | Yes       |
 
+## Financial market calendars
+
+Besides countries, jollyday also supports the closing days of a few financial markets/systems. These are addressed
+via the constants of `HolidayCalendar` (not via an ISO 3166 code) and can be used like any other calendar, e.g.
+`HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.NYSE))`.
+
+| Calendar                                                                             | `HolidayCalendar` constant | Hierarchy key        |
+|--------------------------------------------------------------------------------------|----------------------------|----------------------|
+| New York Stock Exchange (NYSE)                                                       | `NYSE`                     | `nyse`               |
+| New York Stock Exchange Euronext                                                     | `NYSE_EURONEXT`            | `nyse-euronext`      |
+| London Metal Exchange (LME)                                                          | `LONDON_METAL_EXCHANGE`    | `lme`                |
+| TARGET (Trans-European Automated Real-time Gross settlement Express Transfer system) | `TARGET`                   | `target`             |
+| TARGET2-Securities (T2S)                                                             | `TARGET2_SECURITIES`       | `target2-securities` |
+
 ## Holiday types
 
 The following holiday types are supported:

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions.properties
@@ -385,6 +385,8 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = National Day of Community Service
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = National Day of Democracy
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = National Day of Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_BUSH                                       = National Day of Mourning (death of President George H. W. Bush)
+holiday.description.NATIONAL_DAY_OF_MOURNING_CARTER                                     = National Day of Mourning (death of President Jimmy Carter)
 holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = National Day of Mourning (death of Néstor Kirchner)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = National Day of Prayer
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = National Day of Prayer and Thanksgiving
@@ -517,6 +519,7 @@ holiday.description.SECOND_DAY_OF_LUNAR_NEW_YEAR                                
 holiday.description.SELF_GOVERNANCE                                                     = Self-governance Day
 holiday.description.SENIOR_CITIZENS_DAY                                                 = Senior Citizens Day
 holiday.description.SEPARATION                                                          = Separation Day
+holiday.description.SEPTEMBER_11_ATTACKS                                                = September 11 attacks
 holiday.description.SERVICE_REDUCTION                                                   = Service Reduction Day
 holiday.description.SETTE_GIUGNO                                                        = Sette Giugno
 holiday.description.SETTLER                                                             = Settlers' Day

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_de.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_de.properties
@@ -385,6 +385,8 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Nationaler Tag des Gemeinschaftsdienstes
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Nationaler Tag der Demokratie
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Nationaler Tag von Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_BUSH                                       = Nationaler Trauertag (Tod von Präsident George H. W. Bush)
+holiday.description.NATIONAL_DAY_OF_MOURNING_CARTER                                     = Nationaler Trauertag (Tod von Präsident Jimmy Carter)
 holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Nationaler Trauertag (Tod von Néstor Kirchner)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Nationaler Gebetstag
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Nationaler Gebets- und Erntedanktag
@@ -517,6 +519,7 @@ holiday.description.SECOND_DAY_OF_LUNAR_NEW_YEAR                                
 holiday.description.SELF_GOVERNANCE                                                     = Freier Tag für Angestellte
 holiday.description.SENIOR_CITIZENS_DAY                                                 = Tag der Senioren
 holiday.description.SEPARATION                                                          = Tag der Teilung
+holiday.description.SEPTEMBER_11_ATTACKS                                                = Anschläge vom 11. September
 holiday.description.SERVICE_REDUCTION                                                   = Dienstverringerungstag
 holiday.description.SETTE_GIUGNO                                                        = Sette Giugno
 holiday.description.SETTLER                                                             = Tag der Siedler

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_el.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_el.properties
@@ -385,6 +385,8 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Εθνική Ημέρα Κοινοτικής Υπηρεσίας
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Εθνική Ημέρα της Δημοκρατίας
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Εθνική Ημέρα του Γιβραλτάρ
+holiday.description.NATIONAL_DAY_OF_MOURNING_BUSH                                       = Εθνική Ημέρα Πένθους (θάνατος του Προέδρου George H. W. Bush)
+holiday.description.NATIONAL_DAY_OF_MOURNING_CARTER                                     = Εθνική Ημέρα Πένθους (θάνατος του Προέδρου Jimmy Carter)
 holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Εθνική Ημέρα Πένθους (θάνατος του Νέστορ Κίρχνερ)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Εθνική ημέρα προσευχής
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Εθνική ημέρα προσευχής και ευχαριστιών
@@ -517,6 +519,7 @@ holiday.description.SECOND_DAY_OF_LUNAR_NEW_YEAR                                
 holiday.description.SELF_GOVERNANCE                                                     = Ημέρα Αυτοδιοίκησης
 holiday.description.SENIOR_CITIZENS_DAY                                                 = Ημέρα Ηλικιωμένων
 holiday.description.SEPARATION                                                          = Ημέρα χωρισμού
+holiday.description.SEPTEMBER_11_ATTACKS                                                = Επιθέσεις της 11ης Σεπτεμβρίου
 holiday.description.SERVICE_REDUCTION                                                   = Ημέρα μείωσης υπηρεσιών
 holiday.description.SETTE_GIUGNO                                                        = Sette Giugno
 holiday.description.SETTLER                                                             = Ημέρα εποίκων

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_fr.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_fr.properties
@@ -385,6 +385,8 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Journée nationale du service communautaire
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Journée nationale de la démocratie
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Journée Nationale de Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_BUSH                                       = Jour de deuil national (mort du président George H. W. Bush)
+holiday.description.NATIONAL_DAY_OF_MOURNING_CARTER                                     = Jour de deuil national (mort du président Jimmy Carter)
 holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Jour de deuil national (mort de Néstor Kirchner)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Journée nationale de prière
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Journée nationale de prière et d'action de grâce
@@ -517,6 +519,7 @@ holiday.description.SECOND_DAY_OF_LUNAR_NEW_YEAR                                
 holiday.description.SELF_GOVERNANCE                                                     = Self-governance Day
 holiday.description.SENIOR_CITIZENS_DAY                                                 = Journée des personnes âgées
 holiday.description.SEPARATION                                                          = Separation Day
+holiday.description.SEPTEMBER_11_ATTACKS                                                = Attentats du 11 septembre
 holiday.description.SERVICE_REDUCTION                                                   = Service Reduction Day
 holiday.description.SETTE_GIUGNO                                                        = Sette Giugno
 holiday.description.SETTLER                                                             = Settlers' Day

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_nl.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_nl.properties
@@ -385,6 +385,8 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Nationale Dag van Gemeenschapsdienst
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Nationale Dag van de Democratie
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Nationale dag van Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_BUSH                                       = Nationale rouwdag (overlijden van president George H. W. Bush)
+holiday.description.NATIONAL_DAY_OF_MOURNING_CARTER                                     = Nationale rouwdag (overlijden van president Jimmy Carter)
 holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Nationale rouwdag (overlijden van Néstor Kirchner)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Nationale Gebedsdag
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Nationale dag van gebed en dankzegging
@@ -517,6 +519,7 @@ holiday.description.SECOND_DAY_OF_LUNAR_NEW_YEAR                                
 holiday.description.SELF_GOVERNANCE                                                     = Zelfbestuur dag
 holiday.description.SENIOR_CITIZENS_DAY                                                 = Dag van de senioren
 holiday.description.SEPARATION                                                          = Dag van de scheiding
+holiday.description.SEPTEMBER_11_ATTACKS                                                = Aanslagen van 11 september
 holiday.description.SERVICE_REDUCTION                                                   = Dag van de verminderde service
 holiday.description.SETTE_GIUGNO                                                        = Sette Giugno
 holiday.description.SETTLER                                                             = Dag van de kolonisten

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_pt.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_pt.properties
@@ -385,6 +385,8 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Dia Nacional do Serviço Comunitário
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Dia Nacional da Democracia
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Dia Nacional de Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_BUSH                                       = Dia de Luto Nacional (morte do Presidente George H. W. Bush)
+holiday.description.NATIONAL_DAY_OF_MOURNING_CARTER                                     = Dia de Luto Nacional (morte do Presidente Jimmy Carter)
 holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Dia de Luto Nacional (morte de Néstor Kirchner)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Dia Nacional de Oração
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Dia Nacional de Oração e Ação de Graças
@@ -517,6 +519,7 @@ holiday.description.SECOND_DAY_OF_LUNAR_NEW_YEAR                                
 holiday.description.SELF_GOVERNANCE                                                     = Self-governance Day
 holiday.description.SENIOR_CITIZENS_DAY                                                 = Dia dos Idosos
 holiday.description.SEPARATION                                                          = Dia da Separação
+holiday.description.SEPTEMBER_11_ATTACKS                                                = Ataques de 11 de setembro
 holiday.description.SERVICE_REDUCTION                                                   = Service Reduction Day
 holiday.description.SETTE_GIUGNO                                                        = Sette Giugno
 holiday.description.SETTLER                                                             = Settlers' Day

--- a/jollyday-core/src/main/resources/descriptions/holiday_descriptions_sv.properties
+++ b/jollyday-core/src/main/resources/descriptions/holiday_descriptions_sv.properties
@@ -385,6 +385,8 @@ holiday.description.NATIONAL_DAY                                                
 holiday.description.NATIONAL_DAY_OF_COMMUNITY_SERVICE                                   = Nationell dag för samhällstjänst
 holiday.description.NATIONAL_DAY_OF_DEMOCRACY                                           = Demokratins nationaldag
 holiday.description.NATIONAL_DAY_OF_GIBRALTAR                                           = Nationella dagen för Gibraltar
+holiday.description.NATIONAL_DAY_OF_MOURNING_BUSH                                       = Nationell sorgedag (president George H. W. Bushs död)
+holiday.description.NATIONAL_DAY_OF_MOURNING_CARTER                                     = Nationell sorgedag (president Jimmy Carters död)
 holiday.description.NATIONAL_DAY_OF_MOURNING_KIRCHNER                                   = Nationell sorgedag (Néstor Kirchners död)
 holiday.description.NATIONAL_DAY_OF_PRAYER                                              = Nationella bönedagen
 holiday.description.NATIONAL_DAY_OF_PRAYER_AND_THANKSGIVING                             = Nationella böne- och tacksägelsedagen
@@ -517,6 +519,7 @@ holiday.description.SECOND_DAY_OF_LUNAR_NEW_YEAR                                
 holiday.description.SELF_GOVERNANCE                                                     = Självstyrelsedag
 holiday.description.SENIOR_CITIZENS_DAY                                                 = De äldres dag
 holiday.description.SEPARATION                                                          = Separation Day
+holiday.description.SEPTEMBER_11_ATTACKS                                                = Terrorattackerna den 11 september
 holiday.description.SERVICE_REDUCTION                                                   = Service Reduction Day
 holiday.description.SETTE_GIUGNO                                                        = Sette Giugno
 holiday.description.SETTLER                                                             = Settlers' Day

--- a/jollyday-core/src/main/resources/holidays/Holidays_lme.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_lme.xml
@@ -5,23 +5,39 @@
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
   <Holidays>
-    <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
-    <Fixed month="AUGUST" day="28" descriptionPropertiesKey="BANK_HOLIDAY"/>
+    <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR">
+      <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
+      <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
+    </Fixed>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY">
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
       <MovingCondition substitute="MONDAY" with="NEXT" weekday="TUESDAY"/>
     </Fixed>
-    <Fixed month="DECEMBER" day="31" descriptionPropertiesKey="NEW_YEARS_EVE"/>
-    <Fixed month="DECEMBER" day="24" descriptionPropertiesKey="CHRISTMAS_EVE">
-    </Fixed>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS">
       <MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
-    <FixedWeekday which="FIRST" weekday="MONDAY" month="MAY" descriptionPropertiesKey="BANK_HOLIDAY"/>
-    <FixedWeekday which="LAST" weekday="MONDAY" month="MAY" descriptionPropertiesKey="BANK_HOLIDAY"/>
-    <ChristianHoliday type="EASTER"/>
+    <!-- The 2020 Early May bank holiday was moved from the 4th to the 8th of May to mark the 75th anniversary of VE Day -->
+    <Fixed month="MAY" day="8" validFrom="2020" validTo="2020" descriptionPropertiesKey="BANK_HOLIDAY"/>
+    <Fixed month="MAY" day="8" validFrom="2023" validTo="2023" descriptionPropertiesKey="KINGS_CORONATION"/>
+    <!-- The 2012 late May bank holiday was moved to Monday 4 June 2012 for the Queen's Diamond Jubilee -->
+    <Fixed month="JUNE" day="4" validFrom="2012" validTo="2012" descriptionPropertiesKey="BANK_HOLIDAY"/>
+    <!-- The 2022 late May bank holiday was moved from the 30th of May to the 2nd of June for the Queen's Platinum Jubilee -->
+    <Fixed month="JUNE" day="2" validFrom="2022" validTo="2022" descriptionPropertiesKey="BANK_HOLIDAY"/>
+    <Fixed month="JUNE" day="3" validFrom="2022" validTo="2022" descriptionPropertiesKey="QUEENS_PLATINUM_JUBILEE"/>
+    <FixedWeekday which="FIRST" weekday="MONDAY" month="MAY" validTo="2019" descriptionPropertiesKey="BANK_HOLIDAY"/>
+    <FixedWeekday which="FIRST" weekday="MONDAY" month="MAY" validFrom="2021" descriptionPropertiesKey="BANK_HOLIDAY"/>
+    <FixedWeekday which="LAST" weekday="MONDAY" month="MAY" validTo="2011" descriptionPropertiesKey="BANK_HOLIDAY"/>
+    <FixedWeekday which="LAST" weekday="MONDAY" month="MAY" validFrom="2013" validTo="2021" descriptionPropertiesKey="BANK_HOLIDAY"/>
+    <FixedWeekday which="LAST" weekday="MONDAY" month="MAY" validFrom="2023" descriptionPropertiesKey="BANK_HOLIDAY"/>
+    <FixedWeekday which="LAST" weekday="MONDAY" month="AUGUST" descriptionPropertiesKey="BANK_HOLIDAY"/>
     <ChristianHoliday type="GOOD_FRIDAY"/>
+    <ChristianHoliday type="EASTER_MONDAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://www.lme.com/trading/trading-venues/trading-times</Source>
+    <Source>https://www.lme.com/-/media/Files/Trading/LME-Trading-Calendar-2025-2035.pdf</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_nyse.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_nyse.xml
@@ -6,7 +6,6 @@
                xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
   <Holidays>
     <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR">
-      <MovingCondition substitute="SATURDAY" with="PREVIOUS" weekday="FRIDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
     <Fixed month="JUNE" day="19" validFrom="2022" descriptionPropertiesKey="JUNETEENTH">
@@ -21,10 +20,16 @@
       <MovingCondition substitute="SATURDAY" with="PREVIOUS" weekday="FRIDAY"/>
       <MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
     </Fixed>
+    <Fixed month="SEPTEMBER" day="11" validFrom="2001" validTo="2001" descriptionPropertiesKey="SEPTEMBER_11_ATTACKS"/>
+    <Fixed month="SEPTEMBER" day="12" validFrom="2001" validTo="2001" descriptionPropertiesKey="SEPTEMBER_11_ATTACKS"/>
+    <Fixed month="SEPTEMBER" day="13" validFrom="2001" validTo="2001" descriptionPropertiesKey="SEPTEMBER_11_ATTACKS"/>
+    <Fixed month="SEPTEMBER" day="14" validFrom="2001" validTo="2001" descriptionPropertiesKey="SEPTEMBER_11_ATTACKS"/>
     <Fixed month="JUNE" day="11" validFrom="2004" validTo="2004" descriptionPropertiesKey="FUNERAL_OF_PRESIDENT_REAGAN"/>
     <Fixed month="JANUARY" day="2" validFrom="2007" validTo="2007" descriptionPropertiesKey="REMEMBERANCE_OF_PRESIDENT_FORD"/>
     <Fixed month="OCTOBER" day="29" validFrom="2012" validTo="2012" descriptionPropertiesKey="HURRICANE_SANDY"/>
     <Fixed month="OCTOBER" day="30" validFrom="2012" validTo="2012" descriptionPropertiesKey="HURRICANE_SANDY"/>
+    <Fixed month="DECEMBER" day="5" validFrom="2018" validTo="2018" descriptionPropertiesKey="NATIONAL_DAY_OF_MOURNING_BUSH"/>
+    <Fixed month="JANUARY" day="9" validFrom="2025" validTo="2025" descriptionPropertiesKey="NATIONAL_DAY_OF_MOURNING_CARTER"/>
     <FixedWeekday which="THIRD" weekday="MONDAY" month="JANUARY" descriptionPropertiesKey="MARTIN_LUTHER_KING"/>
     <FixedWeekday which="THIRD" weekday="MONDAY" month="FEBRUARY" descriptionPropertiesKey="WASHINGTONS_BIRTHDAY"/>
     <FixedWeekday which="LAST" weekday="MONDAY" month="MAY" descriptionPropertiesKey="MEMORIAL_DAY"/>

--- a/jollyday-core/src/main/resources/holidays/Holidays_nyse_euronext.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_nyse_euronext.xml
@@ -6,9 +6,15 @@
                xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
   <Holidays>
     <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
+    <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-    <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="CHRISTMAS"/>
-    <ChristianHoliday type="ASCENSION_DAY"/>
+    <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
+    <ChristianHoliday type="GOOD_FRIDAY"/>
     <ChristianHoliday type="EASTER_MONDAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://www.euronext.com/en/about/media/euronext-press-releases/nyse-euronext-announces-its-2013-holiday-calendar-and-early</Source>
+    <Source>https://www.euronext.com/en/trading/trading-hours-holidays</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_target.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_target.xml
@@ -8,10 +8,17 @@
     <Fixed validFrom="2000" month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
     <Fixed validFrom="2000" month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
     <Fixed validFrom="1999" month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-    <Fixed validFrom="1999" month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
+    <Fixed validFrom="2000" month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
     <Fixed validFrom="2001" validTo="2001" month="DECEMBER" day="31" descriptionPropertiesKey="NEW_YEARS_EVE"/>
     <Fixed validFrom="1999" validTo="1999" month="DECEMBER" day="31" descriptionPropertiesKey="NEW_YEARS_EVE"/>
     <ChristianHoliday validFrom="2000" type="GOOD_FRIDAY"/>
     <ChristianHoliday validFrom="2000" type="EASTER_MONDAY"/>
   </Holidays>
+
+  <Sources>
+    <Source>https://www.ecb.europa.eu/press/pr/date/1999/html/pr990331.en.html</Source>
+    <Source>https://www.ecb.europa.eu/press/pr/date/1999/html/pr990715_1.en.html</Source>
+    <Source>https://www.ecb.europa.eu/press/pr/date/2000/html/pr000525_2.en.html</Source>
+    <Source>https://www.ecb.europa.eu/press/pr/date/2000/html/pr001214_4.en.html</Source>
+  </Sources>
 </Configuration>

--- a/jollyday-core/src/main/resources/holidays/Holidays_target2_securities.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_target2_securities.xml
@@ -13,6 +13,8 @@
   </Holidays>
 
   <Sources>
+    <Source>https://www.ecb.europa.eu/paym/groups/shared/docs/35c5c-ami-pay-2017-12-06-joint-ami-pay-ami-seco-item-3-t2s-on-target2-closing-days.pdf</Source>
+    <Source>https://www.clearstream.com/clearstream-en/res-library/settlement/t2s-and-t2-downtimes-on-public-holidays--3726990</Source>
     <Source>https://www.bundesbank.de/de/aufgaben/unbarer-zahlungsverkehr/target2-securities</Source>
     <Source>https://www.bundesbank.de/resource/blob/749314/edbf269e7e236ff9dcf3e95dab122a0b/472B63F073F071307366337C94F8C870/feiertage-in-deutschland-1-data.pdf</Source>
   </Sources>

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayLMETest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayLMETest.java
@@ -2,36 +2,79 @@ package de.focus_shift.jollyday.tests.country;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Year;
+
 import static de.focus_shift.jollyday.core.HolidayCalendar.LONDON_METAL_EXCHANGE;
+import static de.focus_shift.jollyday.core.spi.Occurrence.FIRST;
+import static de.focus_shift.jollyday.core.spi.Occurrence.LAST;
 import static de.focus_shift.jollyday.tests.CalendarCheckerApi.assertFor;
 import static java.time.DayOfWeek.MONDAY;
 import static java.time.DayOfWeek.SATURDAY;
 import static java.time.DayOfWeek.SUNDAY;
 import static java.time.DayOfWeek.TUESDAY;
-import static java.time.Month.JANUARY;
 import static java.time.Month.AUGUST;
 import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MAY;
 
 class HolidayLMETest {
 
   @Test
   void ensuresHolidays() {
     assertFor(LONDON_METAL_EXCHANGE)
-      .hasFixedHoliday("NEW_YEAR", JANUARY, 1).and()
-      .hasFixedHoliday("BANK_HOLIDAY", AUGUST, 28).and()
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1)
+        .canBeMovedFrom(SATURDAY, MONDAY)
+        .canBeMovedFrom(SUNDAY, MONDAY)
+      .and()
       .hasFixedHoliday("BOXING_DAY", DECEMBER, 26)
         .canBeMovedFrom(SATURDAY, MONDAY)
         .canBeMovedFrom(SUNDAY, TUESDAY)
         .canBeMovedFrom(MONDAY, TUESDAY)
       .and()
-      .hasFixedHoliday("NEW_YEARS_EVE", DECEMBER, 31).and()
-      .hasFixedHoliday("CHRISTMAS_EVE", DECEMBER, 24).and()
       .hasFixedHoliday("CHRISTMAS", DECEMBER, 25)
         .canBeMovedFrom(SATURDAY, MONDAY)
         .canBeMovedFrom(SUNDAY, MONDAY)
       .and()
-      .hasChristianHoliday("EASTER").and()
+      .hasFixedHoliday("BANK_HOLIDAY", MAY, 8)
+        .notValidBetween(Year.of(1900), Year.of(2019))
+        .validBetween(Year.of(2020), Year.of(2020))
+        .notValidBetween(Year.of(2021), Year.of(2500))
+      .and()
+      .hasFixedHoliday("KINGS_CORONATION", MAY, 8)
+        .notValidBetween(Year.of(1900), Year.of(2022))
+        .validBetween(Year.of(2023), Year.of(2023))
+        .notValidBetween(Year.of(2024), Year.of(2500))
+      .and()
+      .hasFixedHoliday("BANK_HOLIDAY", JUNE, 4)
+        .notValidBetween(Year.of(1900), Year.of(2011))
+        .validBetween(Year.of(2012), Year.of(2012))
+        .notValidBetween(Year.of(2013), Year.of(2500))
+      .and()
+      .hasFixedHoliday("BANK_HOLIDAY", JUNE, 2)
+        .notValidBetween(Year.of(1900), Year.of(2021))
+        .validBetween(Year.of(2022), Year.of(2022))
+        .notValidBetween(Year.of(2023), Year.of(2500))
+      .and()
+      .hasFixedHoliday("QUEENS_PLATINUM_JUBILEE", JUNE, 3)
+        .notValidBetween(Year.of(1900), Year.of(2021))
+        .validBetween(Year.of(2022), Year.of(2022))
+        .notValidBetween(Year.of(2023), Year.of(2500))
+      .and()
+      .hasFixedWeekdayHoliday("BANK_HOLIDAY", FIRST, MONDAY, MAY)
+        .validTo(Year.of(2019))
+        .validFrom(Year.of(2021))
+      .and()
+      .hasFixedWeekdayHoliday("BANK_HOLIDAY", LAST, MONDAY, MAY)
+        .validTo(Year.of(2011))
+        .validBetween(Year.of(2013), Year.of(2021))
+        .validFrom(Year.of(2023))
+      .and()
+      .hasFixedWeekdayHoliday("BANK_HOLIDAY", LAST, MONDAY, AUGUST)
+      .and()
       .hasChristianHoliday("GOOD_FRIDAY")
+      .and()
+      .hasChristianHoliday("EASTER_MONDAY")
       .check();
   }
 }

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayNYSEEuronextTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayNYSEEuronextTest.java
@@ -1,0 +1,30 @@
+package de.focus_shift.jollyday.tests.country;
+
+import org.junit.jupiter.api.Test;
+
+import static de.focus_shift.jollyday.core.HolidayCalendar.NYSE_EURONEXT;
+import static de.focus_shift.jollyday.tests.CalendarCheckerApi.assertFor;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MAY;
+
+class HolidayNYSEEuronextTest {
+
+  @Test
+  void ensuresHolidays() {
+
+    assertFor(NYSE_EURONEXT)
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1)
+      .and()
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1)
+      .and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25)
+      .and()
+      .hasFixedHoliday("STEPHENS", DECEMBER, 26)
+      .and()
+      .hasChristianHoliday("GOOD_FRIDAY")
+      .and()
+      .hasChristianHoliday("EASTER_MONDAY")
+      .check();
+  }
+}

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayNYSETest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayNYSETest.java
@@ -16,6 +16,7 @@ import static java.time.Month.JANUARY;
 import static java.time.Month.JULY;
 import static java.time.Month.JUNE;
 import static java.time.Month.OCTOBER;
+import static java.time.Month.SEPTEMBER;
 
 class HolidayNYSETest {
 
@@ -24,7 +25,6 @@ class HolidayNYSETest {
 
     assertFor(NYSE)
       .hasFixedHoliday("NEW_YEAR", JANUARY, 1)
-        .canBeMovedFrom(SATURDAY, PREVIOUS, FRIDAY)
         .canBeMovedFrom(SUNDAY, MONDAY)
       .and()
       .hasFixedHoliday("JUNETEENTH", JUNE, 19)
@@ -40,6 +40,26 @@ class HolidayNYSETest {
       .hasFixedHoliday("CHRISTMAS", DECEMBER, 25)
         .canBeMovedFrom(SATURDAY, PREVIOUS, FRIDAY)
         .canBeMovedFrom(SUNDAY, MONDAY)
+      .and()
+      .hasFixedHoliday("SEPTEMBER_11_ATTACKS", SEPTEMBER, 11)
+        .notValidBetween(Year.of(1900), Year.of(2000))
+        .validBetween(Year.of(2001), Year.of(2001))
+        .notValidBetween(Year.of(2002), Year.of(2500))
+      .and()
+      .hasFixedHoliday("SEPTEMBER_11_ATTACKS", SEPTEMBER, 12)
+        .notValidBetween(Year.of(1900), Year.of(2000))
+        .validBetween(Year.of(2001), Year.of(2001))
+        .notValidBetween(Year.of(2002), Year.of(2500))
+      .and()
+      .hasFixedHoliday("SEPTEMBER_11_ATTACKS", SEPTEMBER, 13)
+        .notValidBetween(Year.of(1900), Year.of(2000))
+        .validBetween(Year.of(2001), Year.of(2001))
+        .notValidBetween(Year.of(2002), Year.of(2500))
+      .and()
+      .hasFixedHoliday("SEPTEMBER_11_ATTACKS", SEPTEMBER, 14)
+        .notValidBetween(Year.of(1900), Year.of(2000))
+        .validBetween(Year.of(2001), Year.of(2001))
+        .notValidBetween(Year.of(2002), Year.of(2500))
       .and()
       .hasFixedHoliday("FUNERAL_OF_PRESIDENT_REAGAN", JUNE, 11)
         .notValidBetween(Year.of(1900), Year.of(2003))
@@ -60,6 +80,16 @@ class HolidayNYSETest {
         .notValidBetween(Year.of(1900), Year.of(2011))
         .validBetween(Year.of(2012), Year.of(2012))
         .notValidBetween(Year.of(2013), Year.of(2500))
+      .and()
+      .hasFixedHoliday("NATIONAL_DAY_OF_MOURNING_BUSH", DECEMBER, 5)
+        .notValidBetween(Year.of(1900), Year.of(2017))
+        .validBetween(Year.of(2018), Year.of(2018))
+        .notValidBetween(Year.of(2019), Year.of(2500))
+      .and()
+      .hasFixedHoliday("NATIONAL_DAY_OF_MOURNING_CARTER", JANUARY, 9)
+        .notValidBetween(Year.of(1900), Year.of(2024))
+        .validBetween(Year.of(2025), Year.of(2025))
+        .notValidBetween(Year.of(2026), Year.of(2500))
       .and()
       .hasChristianHoliday("GOOD_FRIDAY")
       .check();

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayTargetTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayTargetTest.java
@@ -1,0 +1,44 @@
+package de.focus_shift.jollyday.tests.country;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Year;
+
+import static de.focus_shift.jollyday.core.HolidayCalendar.TARGET;
+import static de.focus_shift.jollyday.tests.CalendarCheckerApi.assertFor;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MAY;
+
+class HolidayTargetTest {
+
+  @Test
+  void ensuresHolidays() {
+
+    assertFor(TARGET)
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1)
+        .validFrom(Year.of(2000))
+      .and()
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1)
+        .validFrom(Year.of(2000))
+      .and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25)
+        .validFrom(Year.of(1999))
+      .and()
+      .hasFixedHoliday("STEPHENS", DECEMBER, 26)
+        .validFrom(Year.of(2000))
+      .and()
+      .hasFixedHoliday("NEW_YEARS_EVE", DECEMBER, 31)
+        .validBetween(Year.of(1999), Year.of(1999))
+        .notValidBetween(Year.of(2000), Year.of(2000))
+        .validBetween(Year.of(2001), Year.of(2001))
+        .notValidBetween(Year.of(2002), Year.of(2500))
+      .and()
+      .hasChristianHoliday("GOOD_FRIDAY")
+        .validFrom(Year.of(2000))
+      .and()
+      .hasChristianHoliday("EASTER_MONDAY")
+        .validFrom(Year.of(2000))
+      .check();
+  }
+}


### PR DESCRIPTION
…lendars

Fixes verified against primary sources: NYSE's New Year's Day no longer incorrectly shifts from Saturday to Friday, and gains its missing 2001/2018/2025 one-off closures; NYSE Euronext drops the non-existent Ascension Day closure and gains Good Friday and Labour Day; TARGET's Boxing Day now has the correct validFrom year. TARGET2-Securities was confirmed correct as-is. Documents all financial market calendars in the README.

closes #1421

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
