### PR TITLE
Improve accuracy of the India holiday calendar

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_in.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_in.xml
@@ -14,6 +14,7 @@
   <Sources>
     <Source>https://www.india.gov.in/calendar</Source>
     <Source>https://en.wikipedia.org/wiki/Public_holidays_in_India</Source>
+    <Source>https://www.staffnews.in/2025/07/list-of-holidays-2026-dopt-order-reg-closed-and-restricted-holidays.html</Source>
     <Source of="ISO 3166">https://www.iso.org/obp/ui/#iso:code:3166:IN</Source>
     <Source of="ISO 3166-2">https://en.wikipedia.org/wiki/ISO_3166-2:IN</Source>
   </Sources>
@@ -21,11 +22,10 @@
   <SubConfigurations hierarchy="an" description="Andaman and Nicobar Islands">
     <Holidays>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -36,17 +36,16 @@
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="ar" description="Arunāchal Pradesh">
     <Holidays>
+      <Fixed month="FEBRUARY" day="20" descriptionPropertiesKey="STATEHOOD"/>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
     </Holidays>
   </SubConfigurations>
 
@@ -54,9 +53,8 @@
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -65,10 +63,9 @@
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
       <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -76,38 +73,39 @@
     <Holidays>
       <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="cg" description="Chhattīsgarh">
     <Holidays>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+      <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="dl" description="Delhi">
     <Holidays>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="dh" description="Dādra and Nagar Haveli and Damān and Diu">
     <Holidays>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
     </Holidays>
   </SubConfigurations>
 
@@ -116,8 +114,8 @@
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
       <Fixed month="DECEMBER" day="3" descriptionPropertiesKey="ST_FRANCIS_XAVIER"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -125,7 +123,7 @@
     <Holidays>
       <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -138,8 +136,11 @@
 
   <SubConfigurations hierarchy="hp" description="Himāchal Pradesh">
     <Holidays>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+      <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -148,15 +149,18 @@
       <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <IslamicHoliday type="ASCHURA"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="jh" description="Jhārkhand">
     <Holidays>
-      <ChristianHoliday type="EASTER"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
+      <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -167,11 +171,10 @@
       <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="KARNATAKA_RAJYOTSAVA"/>
       <Fixed month="NOVEMBER" day="5"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -180,9 +183,10 @@
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
       <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ASCHURA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -193,9 +197,9 @@
   <SubConfigurations hierarchy="ld" description="Lakshadweep">
     <Holidays>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
-      <ChristianHoliday type="GOOD_FRIDAY"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ASCHURA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -204,7 +208,7 @@
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -216,7 +220,7 @@
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -225,9 +229,9 @@
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -235,19 +239,20 @@
     <Holidays>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="mz" description="Mizoram">
     <Holidays>
+      <Fixed month="FEBRUARY" day="20" descriptionPropertiesKey="STATEHOOD"/>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
+      <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -255,9 +260,9 @@
     <Holidays>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -265,8 +270,10 @@
     <Holidays>
       <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+      <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -276,25 +283,29 @@
       <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
-      <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="pb" description="Punjab">
     <Holidays>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+      <ChristianHoliday type="GOOD_FRIDAY"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="rj" description="Rājasthān">
     <Holidays>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+      <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -303,7 +314,6 @@
       <Fixed month="MAY" day="16" descriptionPropertiesKey="STATEHOOD"/>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
     </Holidays>
   </SubConfigurations>
@@ -314,16 +324,22 @@
       <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="ts" description="Telangāna">
-    <Holidays/>
+    <Holidays>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
+      <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+      <ChristianHoliday type="GOOD_FRIDAY"/>
+      <IslamicHoliday type="ASCHURA"/>
+      <IslamicHoliday type="MAWLID_AN_NABI"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
+    </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="tr" description="Tripura">
@@ -331,7 +347,7 @@
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
       <Fixed month="JANUARY" day="23" descriptionPropertiesKey="SUBHAS_CHANDRA_BOSE_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -340,11 +356,10 @@
       <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="MARCH" day="15"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
@@ -352,23 +367,22 @@
     <Holidays>
       <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
       <IslamicHoliday type="MAWLID_AN_NABI"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 
   <SubConfigurations hierarchy="wb" description="West Bengal">
     <Holidays>
       <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
+      <Fixed month="APRIL" day="14" descriptionPropertiesKey="AMBEDKAR_JAYANTI"/>
       <Fixed month="JANUARY" day="23" descriptionPropertiesKey="SUBHAS_CHANDRA_BOSE_JAYANTI"/>
       <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-      <ChristianHoliday type="EASTER"/>
       <ChristianHoliday type="GOOD_FRIDAY"/>
       <IslamicHoliday type="ASCHURA"/>
-      <IslamicHoliday type="ID_UL_ADHA"/>
+      <IslamicHoliday type="ID_UL_ADHA_2"/>
     </Holidays>
   </SubConfigurations>
 </Configuration>

--- a/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayINTest.java
+++ b/jollyday-tests/src/test/java/de/focus_shift/jollyday/tests/country/HolidayINTest.java
@@ -6,8 +6,13 @@ import java.time.Year;
 
 import static de.focus_shift.jollyday.core.HolidayCalendar.INDIA;
 import static de.focus_shift.jollyday.tests.CalendarCheckerApi.assertFor;
-import static java.time.Month.JANUARY;
+import static java.time.Month.APRIL;
 import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MAY;
+import static java.time.Month.NOVEMBER;
 import static java.time.Month.OCTOBER;
 
 class HolidayINTest {
@@ -21,7 +26,263 @@ class HolidayINTest {
       .hasFixedHoliday("REPUBLIC_DAY", JANUARY, 26).validBetween(YEAR_FROM, YEAR_TO).and()
       .hasFixedHoliday("INDEPENDENCE_DAY", AUGUST, 15).validBetween(YEAR_FROM, YEAR_TO).and()
       .hasFixedHoliday("GHANDIS_BIRTHDAY", OCTOBER, 2).validBetween(YEAR_FROM, YEAR_TO).and()
-      .hasIslamicHoliday("ID_AL_FITR_2").validBetween(YEAR_FROM, YEAR_TO)
+      .hasIslamicHoliday("ID_AL_FITR_2").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Andaman and Nicobar Islands
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("an").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("an").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("an").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("an").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("an").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Andhra Pradesh
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("ap").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("ap").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("ap").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("ap").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("ap").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("ap").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Arunāchal Pradesh
+      .hasFixedHoliday("STATEHOOD", FEBRUARY, 20).inSubdivision("ar").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1).inSubdivision("ar").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("ar").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("ar").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Assam
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("as").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("as").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("as").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("as").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Bihār
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("br").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("br").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("br").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("br").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("br").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("br").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Chandīgarh
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("ch").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("ch").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("ch").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("ch").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("ch").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Chhattīsgarh
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("cg").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("cg").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("cg").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("cg").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("cg").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("cg").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Delhi
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("dl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("dl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("dl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("dl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("dl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("dl").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Dādra and Nagar Haveli and Damān and Diu
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("dh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("dh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("dh").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Goa
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("ga").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("ST_FRANCIS_XAVIER", DECEMBER, 3).inSubdivision("ga").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("ga").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("ga").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("ga").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Gujarāt
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("gj").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("gj").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("gj").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Haryāna
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("hr").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("hr").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Himāchal Pradesh
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("hp").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("hp").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("hp").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("hp").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("hp").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Jammu and Kashmīr
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("jk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("jk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("jk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("jk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("jk").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Jhārkhand
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("jh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("jh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("jh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("jh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("jh").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Karnātaka
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("ka").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("ka").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("KARNATAKA_RAJYOTSAVA", NOVEMBER, 1).inSubdivision("ka").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("ka").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("ka").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("ka").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("ka").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("ka").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Kerala
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("kl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("kl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("kl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("kl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("kl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("kl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("kl").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Lakshadweep
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("ld").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("ld").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("ld").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("ld").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Madhya Pradesh
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("mp").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("mp").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("mp").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("mp").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Mahārāshtra
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("mh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("mh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("SHIVAJI_JAYANTI", FEBRUARY, 19).inSubdivision("mh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("mh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("mh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("mh").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("mh").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Manipur
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("mn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1).inSubdivision("mn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("mn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("mn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("mn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("mn").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Meghālaya
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1).inSubdivision("ml").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("ml").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("ml").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("ml").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Mizoram
+      .hasFixedHoliday("STATEHOOD", FEBRUARY, 20).inSubdivision("mz").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1).inSubdivision("mz").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("mz").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("mz").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("mz").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("mz").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("mz").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Nāgāland
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1).inSubdivision("nl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("nl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("nl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("nl").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("nl").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Odisha
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("od").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("od").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("od").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("od").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("od").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("od").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Puducherry
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("py").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("py").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1).inSubdivision("py").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("py").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("py").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("py").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("py").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Punjab
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("pb").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("pb").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("pb").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("pb").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Rājasthān
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("rj").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("rj").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("rj").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("rj").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("rj").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("rj").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Sikkim
+      .hasFixedHoliday("STATEHOOD", MAY, 16).inSubdivision("sk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1).inSubdivision("sk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("sk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("sk").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Tamil Nādu
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("tn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("tn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("NEW_YEAR", JANUARY, 1).inSubdivision("tn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("tn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("tn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("tn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("tn").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("tn").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Telangāna
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("ts").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("ts").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("ts").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("ts").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("ts").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("ts").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Tripura
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("tr").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("SUBHAS_CHANDRA_BOSE_JAYANTI", JANUARY, 23).inSubdivision("tr").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("tr").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("tr").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Uttar Pradesh
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("up").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("up").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("up").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("up").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("up").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("up").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // Uttarākhand
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("uk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("uk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("uk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("uk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("MAWLID_AN_NABI").inSubdivision("uk").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("uk").validBetween(YEAR_FROM, YEAR_TO).and()
+
+      // West Bengal
+      .hasFixedHoliday("LABOUR_DAY", MAY, 1).inSubdivision("wb").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("AMBEDKAR_JAYANTI", APRIL, 14).inSubdivision("wb").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("SUBHAS_CHANDRA_BOSE_JAYANTI", JANUARY, 23).inSubdivision("wb").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasFixedHoliday("CHRISTMAS", DECEMBER, 25).inSubdivision("wb").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasChristianHoliday("GOOD_FRIDAY").inSubdivision("wb").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ASCHURA").inSubdivision("wb").validBetween(YEAR_FROM, YEAR_TO).and()
+      .hasIslamicHoliday("ID_UL_ADHA_2").inSubdivision("wb").validBetween(YEAR_FROM, YEAR_TO)
       .check();
   }
 }


### PR DESCRIPTION
Audited every state/UT against official gazettes (state GAD/Personnel Dept. notifications) and cross-checked against Wikipedia's public holidays list, per the sources already cited in Holidays_in.xml.

- Eid al-Adha (Bakrid) is gazetted in India one day later than the plain astronomical calculation, exactly like Eid al-Fitr (#280). Confirmed via DoPT-reported dates for 2022-2026. Switch every ID_UL_ADHA entry to ID_UL_ADHA_2.
- Easter Sunday is not a distinct gazetted public holiday anywhere in India - it's always a Sunday, already the weekly off day. Confirmed against primary gazettes for an, ar, as, cg, dl, dh, ka, kl, mn, ml, nl, py, tn, wb (restricted/optional lists only, never compulsory). Remove the spurious ChristianHoliday EASTER entries.
- No Indian jurisdiction grants a substitute/compensatory holiday when a gazetted holiday falls on a Sunday (explicit DoPT circular: "No substitute holiday should be allowed..."). Confirms no shifting logic is needed for the national holidays.
- Fill genuine gaps found against primary sources: missing Ambedkar Jayanti, Good Friday, Mawlid an-Nabi and Ashura entries across several states (cg, dl, hp, jh, kl, ld, mz, od, pb, rj, wb), a completely missing Christmas entry for Jharkhand, and Eid al-Adha for Goa. Build out Telangana's config, which was entirely empty.
- Remove entries that turned out to only be restricted/optional holidays, not compulsory ones: Eid al-Adha for Arunachal Pradesh and Dadra & Nagar Haveli/Daman & Diu, Ashura for Puducherry, Good Friday for Lakshadweep.
- Add Statehood Day for Arunachal Pradesh and Mizoram (both 20 Feb 1987), reusing the existing STATEHOOD key already used for Sikkim.

The two unlabeled legacy entries (Karnataka Nov 5, Uttar Pradesh Mar 15) are left untouched - independent research reached the same conclusion as the prior audit that added the documented allowlist exception for them: no credible source ties either date to a specific year, so they're not touched rather than guessed at.

Several lower-confidence findings (conflicting secondary sources for Gujarat/Ladakh, single-source state-specific days like Guru Ghasidas Jayanti or Lachit Divas) are intentionally left out of this change and would need their own primary-source confirmation and new description keys.

Extend HolidayINTest to cover every subdivision's configuration.

closes #1426 

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
