### PR TITLE
cz: add primary legal source confirming no weekend-substitution rule

### DIFF
--- a/jollyday-core/src/main/resources/holidays/Holidays_cz.xml
+++ b/jollyday-core/src/main/resources/holidays/Holidays_cz.xml
@@ -24,6 +24,7 @@
     <Source>https://en.wikipedia.org/wiki/Public_holidays_in_the_Czech_Republic</Source>
     <Source of="ISO 3166">https://www.iso.org/obp/ui/#iso:code:3166:CZ</Source>
     <Source of="ISO 3166-2">https://en.wikipedia.org/wiki/ISO_3166-2:CZ</Source>
+    <Source of="Legal basis (no weekend-substitution rule exists)">https://ppropo.mpsv.cz/zakon_245_2000</Source>
   </Sources>
 
 </Configuration>


### PR DESCRIPTION
Audited against the Wikipedia source and Zakon c. 245/2000 Sb. (via ppropo.mpsv.cz): the existing 13-holiday list is already complete and accurate, and Czech law has no mechanism to move or compensate a holiday falling on a weekend, unlike Slovakia. No data changes needed; this adds the primary source for future maintainers.

closes #1439

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
