### PR TITLE
Let the jackson module read java.xml

### DIFF
--- a/jollyday-jackson/src/main/java/module-info.java
+++ b/jollyday-jackson/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module de.focus_shift.jollyday.jackson {
     com.fasterxml.jackson.annotation,
     tools.jackson.databind;
 
+  requires java.xml;
   requires tools.jackson.databind;
   requires tools.jackson.dataformat.xml;
   requires de.focus_shift.jollyday.core;


### PR DESCRIPTION
## Summary
- The build of `main` is currently red: `5c3faea4` ("Harden Jackson XML unmarshalling against XXE explicitly") uses `javax.xml.stream.XMLInputFactory` in `JacksonXMLMapper`, but the module descriptor of `jollyday-jackson` does not `requires java.xml`, so compilation fails with `package javax.xml.stream is not visible (package javax.xml.stream is declared in module java.xml, but module de.focus_shift.jollyday.jackson does not read it)`.
- `jollyday-jaxb` received the same `requires java.xml;` clause together with its own hardening in `821c20c8`, `jollyday-jackson` was missing it.

## Test plan
- [x] `./mvnw verify` fails on a clean checkout of `main` and succeeds with this one-line change
- [x] `./mvnw verify -Dtests.groups=BenchmarkTest` passes